### PR TITLE
Ensure only new commits are submitted as builds

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/backend/ProjectsBackend.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/backend/ProjectsBackend.java
@@ -101,7 +101,7 @@ public class ProjectsBackend {
 			client.users().ensureExists(userModel);
 
 			RepositoryModel repoModel = new RepositoryModel();
-			repoModel.setName(group.getRepoName());
+			repoModel.setName(group.getRepositoryName());
 			repoModel.setPermissions(ImmutableMap.<String, Level> builder()
 					.put(userModel.getName(), Level.READ_WRITE)
 					.build());

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/BuildResults.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/BuildResults.java
@@ -1,0 +1,50 @@
+package nl.tudelft.ewi.devhub.server.database.controllers;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
+
+import lombok.extern.slf4j.Slf4j;
+import nl.tudelft.ewi.devhub.server.database.entities.BuildResult;
+import nl.tudelft.ewi.devhub.server.database.entities.Group;
+import nl.tudelft.ewi.devhub.server.database.entities.QBuildResult;
+
+import com.google.inject.persist.Transactional;
+
+@Slf4j
+public class BuildResults extends Controller<BuildResult> {
+
+	@Inject
+	public BuildResults(EntityManager entityManager) {
+		super(entityManager);
+	}
+
+	@Transactional
+	public BuildResult find(Group group, String commitId) {
+		BuildResult result = query().from(QBuildResult.buildResult)
+				.where(QBuildResult.buildResult.repository.groupId.eq(group.getGroupId()))
+				.where(QBuildResult.buildResult.commitId.eq(commitId))
+				.singleResult(QBuildResult.buildResult);
+		
+		if (result == null) {
+			throw new EntityNotFoundException();
+		}
+		return result;
+	}
+	
+	@Transactional
+	public boolean exists(Group group, String commitId) {
+		try {
+			find(group, commitId);
+			return true;
+		}
+		catch (EntityNotFoundException e) {
+			return false;
+		}
+		catch (Throwable e) {
+			log.error(e.getMessage(), e);
+			return false;
+		}
+	}
+	
+}

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/BuildServers.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/BuildServers.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
-import javax.ws.rs.NotFoundException;
+import javax.persistence.EntityNotFoundException;
 
 import nl.tudelft.ewi.devhub.server.database.entities.BuildServer;
 import nl.tudelft.ewi.devhub.server.database.entities.QBuildServer;
@@ -32,7 +32,7 @@ public class BuildServers extends Controller<BuildServer> {
 				.singleResult(QBuildServer.buildServer);
 		
 		if (buildServer == null) {
-			throw new NotFoundException();
+			throw new EntityNotFoundException();
 		}
 		return buildServer;
 	}
@@ -45,7 +45,7 @@ public class BuildServers extends Controller<BuildServer> {
 				.singleResult(QBuildServer.buildServer);
 		
 		if (buildServer == null) {
-			throw new NotFoundException();
+			throw new EntityNotFoundException();
 		}
 		return buildServer;
 	}

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Groups.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Groups.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
 
 import nl.tudelft.ewi.devhub.server.database.entities.Course;
 import nl.tudelft.ewi.devhub.server.database.entities.Group;
@@ -16,6 +17,18 @@ public class Groups extends Controller<Group> {
 	@Inject
 	public Groups(EntityManager entityManager) {
 		super(entityManager);
+	}
+	
+	@Transactional
+	public Group findByRepoName(String repoName) {
+		Group group = query().from(QGroup.group)
+				.where(QGroup.group.repositoryName.eq(repoName))
+				.singleResult(QGroup.group);
+		
+		if (group == null) {
+			throw new EntityNotFoundException();
+		}
+		return group;
 	}
 
 	@Transactional

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/BuildResult.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/BuildResult.java
@@ -1,0 +1,51 @@
+package nl.tudelft.ewi.devhub.server.database.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+
+import lombok.Data;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+@Data
+@Entity
+@Table(name = "build_results")
+public class BuildResult {
+
+	public static BuildResult newBuildResult(Group group, String commit) {
+		BuildResult result = new BuildResult();
+		result.setRepository(group);
+		result.setCommitId(commit);
+		result.setSuccess(null);
+		result.setLog(null);
+		return result;
+	}
+	
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id;
+
+	@NotNull
+	@ManyToOne
+	@JoinColumn(name = "repository_id")
+	private Group repository;
+	
+	@NotEmpty
+	@Column(name = "commit_id", columnDefinition = "char(40)")
+	private String commitId;
+	
+	@Column(name = "success")
+	private Boolean success;
+	
+	@Column(name = "log")
+	private String log;
+	
+}

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Group.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Group.java
@@ -40,8 +40,8 @@ public class Group {
 	@OneToMany(mappedBy = "group", fetch = FetchType.LAZY)
 	private Set<GroupMembership> memberships;
 
-	public String getRepoName() {
-		return "courses/" + getCourse().getCode().toLowerCase() + "/group-" + getGroupNumber();
-	}
-
+	@NotNull
+	@Column(name = "repository_name")
+	private String repositoryName;
+	
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/HooksResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/HooksResource.java
@@ -12,14 +12,22 @@ import javax.ws.rs.core.MediaType;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import nl.tudelft.ewi.build.jaxrs.models.BuildRequest;
-import nl.tudelft.ewi.build.jaxrs.models.BuildResult;
 import nl.tudelft.ewi.build.jaxrs.models.GitSource;
 import nl.tudelft.ewi.build.jaxrs.models.MavenBuildInstruction;
 import nl.tudelft.ewi.devhub.server.DevhubServer;
 import nl.tudelft.ewi.devhub.server.backend.BuildsBackend;
+import nl.tudelft.ewi.devhub.server.database.controllers.BuildResults;
+import nl.tudelft.ewi.devhub.server.database.controllers.Groups;
+import nl.tudelft.ewi.devhub.server.database.entities.BuildResult;
+import nl.tudelft.ewi.devhub.server.database.entities.Group;
 import nl.tudelft.ewi.devhub.server.web.filters.RequireAuthentication;
+import nl.tudelft.ewi.git.client.GitServerClient;
+import nl.tudelft.ewi.git.models.BranchModel;
+import nl.tudelft.ewi.git.models.DetailedRepositoryModel;
 
 import org.jboss.resteasy.plugins.guice.RequestScoped;
+
+import com.google.inject.persist.Transactional;
 
 @Slf4j
 @Path("hooks")
@@ -30,48 +38,69 @@ public class HooksResource {
 
 	@Data
 	private static class GitPush {
-		private String repositoryUrl;
-		private String branch;
-		private String commitId;
+		private String repository;
 	}
 
 	private final BuildsBackend buildBackend;
+	private final GitServerClient client;
+	private final BuildResults buildResults;
+	private final Groups groups;
 
 	@Inject
-	HooksResource(BuildsBackend buildBackend) {
+	HooksResource(BuildsBackend buildBackend, GitServerClient client, BuildResults buildResults, Groups groups) {
 		this.buildBackend = buildBackend;
+		this.client = client;
+		this.buildResults = buildResults;
+		this.groups = groups;
 	}
 
 	@POST
 	@Path("git-push")
+	@Transactional
 	public void onGitPush(@Context HttpServletRequest request, GitPush push) {
 		log.info("Received git-push event: {}", push);
+		
+		DetailedRepositoryModel repository = client.repositories().retrieve(push.getRepository());
 		
 		MavenBuildInstruction instruction = new MavenBuildInstruction();
 		instruction.setWithDisplay(true);
 		instruction.setPhases(new String[] { "package" });
 
-		GitSource source = new GitSource();
-		source.setRepositoryUrl(push.getRepositoryUrl());
-		source.setBranchName(push.getBranch());
-		source.setCommitId(push.getCommitId());
-
-		BuildRequest buildRequest = new BuildRequest();
-		buildRequest.setCallbackUrl(DevhubServer.getHostUrl(request) + "/hooks/build-result");
-		buildRequest.setInstruction(instruction);
-		buildRequest.setSource(source);
-
-		buildBackend.offerBuild(buildRequest);
+		Group group = groups.findByRepoName(push.getRepository());
+		for (BranchModel branch : repository.getBranches()) {
+			if (branch.getSimpleName().equals("HEAD")) {
+				continue;
+			}
+			if (buildResults.exists(group, branch.getCommit())) {
+				continue;
+			}
+			
+			log.info("Submitting a build for branch: {} of repository: {}", branch.getName(), repository.getName());
+			
+			GitSource source = new GitSource();
+			source.setRepositoryUrl(repository.getUrl());
+			source.setBranchName(branch.getName());
+			source.setCommitId(branch.getCommit());
+	
+			BuildRequest buildRequest = new BuildRequest();
+			buildRequest.setCallbackUrl(DevhubServer.getHostUrl(request) + "/hooks/build-result");
+			buildRequest.setInstruction(instruction);
+			buildRequest.setSource(source);
+	
+			buildBackend.offerBuild(buildRequest);
+			buildResults.persist(BuildResult.newBuildResult(group, branch.getCommit()));
+		}
 	}
 
 	@POST
 	@Path("build-result")
 	@RequireAuthentication
-	public void onBuildResult(BuildResult buildResult) {
-		log.info("STATUS: " + buildResult.getStatus());
+	@Transactional
+	public void onBuildResult(nl.tudelft.ewi.build.jaxrs.models.BuildResult buildResult) {
 		for (String line : buildResult.getLogLines()) {
 			log.info("LOG: " + line);
 		}
+		log.info("STATUS: " + buildResult.getStatus());
 	}
 	
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectsResource.java
@@ -130,7 +130,7 @@ public class ProjectsResource {
 		Map<String, Object> parameters = Maps.newHashMap();
 		parameters.put("user", requester);
 		parameters.put("group", group);
-		parameters.put("repository", client.repositories().retrieve(group.getRepoName()));
+		parameters.put("repository", client.repositories().retrieve(group.getRepositoryName()));
 
 		List<Locale> locales = Collections.list(request.getLocales());
 		return Response.ok()

--- a/src/main/resources/changelog.xml
+++ b/src/main/resources/changelog.xml
@@ -135,4 +135,35 @@
 		</createTable>
 	</changeSet>
 	
+	<changeSet id="add_build_results_table" author="Michael de Jong">
+		<createTable tableName="build_results">
+			<column name="id" type="bigint" autoIncrement="true">
+				<constraints primaryKey="true" />
+			</column>
+			<column name="repository_id" type="bigint">
+				<constraints nullable="false" />
+			</column>
+			<column name="commit_id" type="char(40)">
+				<constraints nullable="false" />
+			</column>
+			<column name="success" type="boolean" />
+			<column name="log" type="text" />
+		</createTable>
+		
+		<addForeignKeyConstraint constraintName="repository_ref_in_build_results"
+			baseTableName="build_results" baseColumnNames="repository_id"
+			referencedTableName="groups" referencedColumnNames="id" />
+			
+		<addUniqueConstraint columnNames="repository_id,commit_id" tableName="build_results" />
+	</changeSet>
+	
+	<changeSet id="add_repo_name_to_groups_table" author="Michael de Jong">
+		<addColumn tableName="groups">
+			<column name="repository_name" type="varchar(255)">
+				<constraints nullable="false" />
+			</column>
+		</addColumn>
+		<addUniqueConstraint columnNames="repository_name" tableName="groups" />
+	</changeSet>
+	
 </databaseChangeLog>


### PR DESCRIPTION
When new pushes are specified through the hook interface, we should only build commits which have not yet been built.
