### PR TITLE
Allow courses to define a template repo.

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/backend/ProjectsBackend.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/backend/ProjectsBackend.java
@@ -13,7 +13,7 @@ import nl.tudelft.ewi.devhub.server.database.entities.GroupMembership;
 import nl.tudelft.ewi.devhub.server.database.entities.User;
 import nl.tudelft.ewi.devhub.server.web.errors.ApiError;
 import nl.tudelft.ewi.git.client.GitServerClient;
-import nl.tudelft.ewi.git.models.RepositoryModel;
+import nl.tudelft.ewi.git.models.CreateRepositoryModel;
 import nl.tudelft.ewi.git.models.RepositoryModel.Level;
 import nl.tudelft.ewi.git.models.UserModel;
 
@@ -102,8 +102,9 @@ public class ProjectsBackend {
 			userModel.setName(requester.getNetId());
 			client.users().ensureExists(userModel);
 
-			RepositoryModel repoModel = new RepositoryModel();
+			CreateRepositoryModel repoModel = new CreateRepositoryModel();
 			repoModel.setName(group.getRepositoryName());
+			repoModel.setTemplateRepository(course.getTemplateRepositoryUrl());
 			repoModel.setPermissions(ImmutableMap.<String, Level> builder()
 					.put(userModel.getName(), Level.READ_WRITE)
 					.build());

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Course.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Course.java
@@ -45,6 +45,9 @@ public class Course {
 	@Column(name = "end")
 	private Date end;
 	
+	@Column(name = "template_repository_url")
+	private String templateRepositoryUrl;
+	
 	@OrderBy("groupNumber ASC")
 	@OneToMany(mappedBy = "course", fetch = FetchType.LAZY)
 	private List<Group> groups;

--- a/src/main/resources/changelog.xml
+++ b/src/main/resources/changelog.xml
@@ -77,45 +77,11 @@
 			<column name="net_id">mdejong2</column>
 		</insert>
 		<insert tableName="courses">
-			<column name="code">TI2210</column>
-			<column name="name">Software Quality and Testing</column>
-			<column name="start">2013-02-01 00:00:00</column>
-			<column name="end">2013-05-01 00:00:00</column>
-		</insert>
-		<insert tableName="courses">
-			<column name="code">TI2210</column>
-			<column name="name">Software Quality and Testing</column>
+			<column name="code">TI1705</column>
+			<column name="name">Softwarekwaliteit & Testen</column>
+			<column name="template_repository_url">https://github.com/SERG-Delft/jpacman-template.git</column>
 			<column name="start">2014-01-01 00:00:00</column>
 		</insert>
-		<insert tableName="courses">
-			<column name="code">IN4303</column>
-			<column name="name">Compiler Construction</column>
-			<column name="start">2014-01-01 00:00:00</column>
-		</insert>
-		<!-- <insert tableName="groups">
-			<column name="course_id">1</column>
-			<column name="group_number">1</column>
-		</insert>
-		<insert tableName="groups">
-			<column name="course_id">2</column>
-			<column name="group_number">1</column>
-		</insert>
-		<insert tableName="groups">
-			<column name="course_id">3</column>
-			<column name="group_number">1</column>
-		</insert>
-		<insert tableName="group_memberships">
-			<column name="group_id">1</column>
-			<column name="user_id">1</column>
-		</insert>
-		<insert tableName="group_memberships">
-			<column name="group_id">2</column>
-			<column name="user_id">1</column>
-		</insert>
-		<insert tableName="group_memberships">
-			<column name="group_id">3</column>
-			<column name="user_id">1</column>
-		</insert> -->
 	</changeSet>
 	
 	<changeSet id="add_build_servers_table" author="Michael de Jong">
@@ -164,6 +130,12 @@
 			</column>
 		</addColumn>
 		<addUniqueConstraint columnNames="repository_name" tableName="groups" />
+	</changeSet>
+	
+	<changeSet id="add_template_repo_to_courses" author="Michael de Jong">
+		<addColumn tableName="courses">
+			<column name="template_repository_url" type="varchar(255)" />
+		</addColumn>
 	</changeSet>
 	
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds support for template repositories. When provisioning a new `Group` repository for a certain `Course`. We can use a `Course` defined template repository to base the new repository on.
