### PR TITLE
Fix for listing the last deliveries for an assignment

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Deliveries.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Deliveries.java
@@ -64,7 +64,7 @@ public class Deliveries extends Controller<Delivery> {
             .transform(groupBy(QDelivery.delivery.group).as(list(QDelivery.delivery)));
 
         return deliveriesMap.values().stream().map((deliveries) ->
-                deliveries.stream().min(Comparator.<Delivery> naturalOrder()).get())
+                deliveries.stream().max(Comparator.<Delivery> naturalOrder()).get())
             .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Instead of showing the last delivery for every group for an assignment, we showed the first.

Merge into Devhub 3.0.0 #81