### PR TITLE
Type(type = org.hibernate.type.TextType) annotations

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Assignment.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Assignment.java
@@ -2,6 +2,7 @@ package nl.tudelft.ewi.devhub.server.database.entities;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.Type;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.annotation.Nullable;
@@ -42,9 +43,9 @@ public class Assignment {
     @Column(name = "name")
     private String name;
 
-    @Lob
     @Nullable
     @Column(name = "summary")
+    @Type(type = "org.hibernate.type.TextType")
     private String summary;
 
     @Nullable

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/BuildResult.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/BuildResult.java
@@ -12,7 +12,7 @@ import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
 import lombok.Data;
-
+import org.hibernate.annotations.Type;
 import org.hibernate.validator.constraints.NotEmpty;
 
 @Data
@@ -46,7 +46,7 @@ public class BuildResult {
 	@Column(name = "success")
 	private Boolean success;
 
-	@Lob
+	@Type(type = "org.hibernate.type.TextType")
 	@Column(name = "log")
 	private String log;
 

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Comment.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Comment.java
@@ -3,6 +3,7 @@ package nl.tudelft.ewi.devhub.server.database.entities;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.Basic;
@@ -36,10 +37,8 @@ public abstract class Comment implements Comparable<Comment> {
     @GenericGenerator(name="increment", strategy = "increment")
     private long commentId;
 
-    @Lob
-    @NotEmpty
-    @Basic(fetch= FetchType.LAZY)
     @Column(name = "content")
+    @Type(type = "org.hibernate.type.TextType")
     private String content;
 
     @NotNull

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Delivery.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Delivery.java
@@ -2,6 +2,7 @@ package nl.tudelft.ewi.devhub.server.database.entities;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -84,9 +85,8 @@ public class Delivery implements Comparable<Delivery> {
     @Embedded
     private Review review;
 
-    @Lob
-    @Basic(fetch=FetchType.LAZY)
     @Column(name = "notes")
+    @Type(type = "org.hibernate.type.TextType")
     private String notes;
 
     @JoinColumn(name = "delivery_id")
@@ -115,9 +115,8 @@ public class Delivery implements Comparable<Delivery> {
         @ManyToOne(fetch = FetchType.LAZY)
         private User reviewUser;
 
-        @Lob
-        @Basic(fetch=FetchType.LAZY)
         @Column(name = "commentary")
+        @Type(type = "org.hibernate.type.TextType")
         private String commentary;
 
     }

--- a/src/test/resources/persistence.properties
+++ b/src/test/resources/persistence.properties
@@ -1,6 +1,6 @@
-hibernate.dialect = org.hibernate.dialect.H2Dialect
+hibernate.dialect = org.hibernate.dialect.PostgreSQL9Dialect
 hibernate.connection.driver_class = org.h2.Driver
-javax.persistence.jdbc.url = jdbc:h2:devhub-test
+javax.persistence.jdbc.url = jdbc:h2:./devhub-test;MODE=PostgreSQL
 javax.persistence.jdbc.user = admin
 javax.persistence.jdbc.password = admin
 liquibase.liquibase-strategy = drop-create


### PR DESCRIPTION
Added the `@Type(type = "org.hibernate.type.TextType")` annotations to the entity classes to work properly with Postgres. I say properly because it already worked under Postgres, but after querying the database through `psql` I found that the `TEXT` fields were stored as blobs and showed up as numbers. I have tried various variants on the web, with/without `@Lob`, `@Basic`, and the newer `
@Type(type="org.hibernate.type.StringClobType")`. Even more difficult was getting it to work under H2.

For now this seems to be the only way to go:
- Annotate `TEXT` types with `@Type(type = "org.hibernate.type.TextType")`
- Run H2 under `PostgreSQL` mode and use a Postgres dialect for Hibernate.

#81