### PR TITLE
Suggested fix for building builds in branches

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/HooksResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/HooksResource.java
@@ -106,7 +106,7 @@ public class HooksResource extends Resource {
 
 			GitSource source = new GitSource();
 			source.setRepositoryUrl(repository.getUrl());
-			source.setBranchName(branch.getName());
+			source.setBranchName(branch.getSimpleName());
 			source.setCommitId(commitId);
 
 			StringBuilder callbackBuilder = new StringBuilder();


### PR DESCRIPTION
Because the git sever uses the bare repo's for some of the requests, the branches have refs like: `ref/HEADS/branch-name`. Cloned non-bare repositories can't checkout these branches, but should instead checkout `origin/branch-name`. 