### PR TITLE
Fixed adding assistants with ucase

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/backend/CoursesBackend.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/backend/CoursesBackend.java
@@ -89,7 +89,7 @@ public class CoursesBackend {
      * @param newAssistants List of users assisting this course
      * @throws GitClientException if an GitClientException occurs
      */
-    public void setAssistants(Course course, List<User> newAssistants) throws GitClientException {
+    public void setAssistants(Course course, Collection<User> newAssistants) throws GitClientException {
         Preconditions.checkNotNull(course);
         Preconditions.checkNotNull(newAssistants);
         checkAdmin();

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Users.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Users.java
@@ -66,18 +66,14 @@ public class Users extends Controller<User> {
 			return Maps.newHashMap();
 		}
 
-		List<String> lowerCasedNetIds = netIds.stream().map(String::toLowerCase).collect(Collectors.toList());
+		List<String> lowerCasedNetIds = netIds.stream()
+				.map(String::toLowerCase)
+				.collect(Collectors.toList());
 
-		List<User> result = query().from(QUser.user)
+		return query().from(QUser.user)
 			.where(QUser.user.netId.toLowerCase().in(lowerCasedNetIds))
 			.orderBy(QUser.user.netId.toLowerCase().asc())
-			.list(QUser.user);
-
-		Map<String, User> mapping = Maps.newHashMap();
-		for (User user : result) {
-			mapping.put(user.getNetId(), user);
-		}
-		return mapping;
+			.map(QUser.user.netId, QUser.user);
 	}
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/CourseAssistantsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/CourseAssistantsResource.java
@@ -90,7 +90,7 @@ public class CourseAssistantsResource extends Resource {
             session.removeAttribute("courses.course.assistants");
         }
 
-        List<User> members = (List<User>) session.getAttribute("courses.course.assistants");
+        Collection<User> members = (Collection<User>) session.getAttribute("courses.course.assistants");
         if(members == null)
             members = course.getAssistants();
 

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/CourseAssistantsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/CourseAssistantsResource.java
@@ -115,7 +115,7 @@ public class CourseAssistantsResource extends Resource {
 
         HttpSession session = request.getSession();
         Course course = courses.find(courseCode);
-        List<User> members = (List<User>) session.getAttribute("courses.course.assistants");
+        Collection<User> members = (Collection<User>) session.getAttribute("courses.course.assistants");
 
         Map<String, Object> parameters = Maps.newHashMap();
         parameters.put("user", currentUser);
@@ -144,19 +144,19 @@ public class CourseAssistantsResource extends Resource {
         Course course = courses.find(courseCode);
 
         if (step == 1) {
-            List<User> courseAssistants = getCourseAssistants(request);
+            Collection<User> courseAssistants = getCourseAssistants(request);
             session.setAttribute("courses.course.assistants", courseAssistants);
             return redirect("/courses/" + courseCode + "/assistants?step=2");
         }
 
-        List<User> courseAssistants = (List<User>) session.getAttribute("courses.course.assistants");
+        Collection<User> courseAssistants = (Collection<User>) session.getAttribute("courses.course.assistants");
         coursesBackend.setAssistants(course, courseAssistants);
 
         session.removeAttribute("courses.course.assistants");
         return redirect("/courses/" + courseCode);
     }
 
-    private List<User> getCourseAssistants(HttpServletRequest request) {
+    private Collection<User> getCourseAssistants(HttpServletRequest request) {
         String netId;
         int memberId = 1;
         Set<String> netIds = Sets.newHashSet();
@@ -166,9 +166,7 @@ public class CourseAssistantsResource extends Resource {
         }
 
         Map<String, User> members = users.mapByNetIds(netIds);
-        return netIds.stream()
-            .map(members::get)
-            .collect(Collectors.toList());
+        return members.values();
     }
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/CourseEnrollResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/CourseEnrollResource.java
@@ -84,7 +84,7 @@ public class CourseEnrollResource extends Resource {
             session.removeAttribute("projects.setup.members");
         }
 
-        List<User> members = (List<User>) session.getAttribute("projects.setup.members");
+        Collection<User> members = (Collection<User>) session.getAttribute("projects.setup.members");
 
         int maxGroupSize = getMaxGroupSize(course);
         int minGroupSize = getMinGroupSize(course);
@@ -112,7 +112,7 @@ public class CourseEnrollResource extends Resource {
 
         HttpSession session = request.getSession();
         Course course = courses.find(courseCode);
-        List<User> members = (List<User>) session.getAttribute("projects.setup.members");
+        Collection<User> members = (Collection<User>) session.getAttribute("projects.setup.members");
 
         Map<String, Object> parameters = Maps.newHashMap();
         parameters.put("user", currentUser);
@@ -137,7 +137,7 @@ public class CourseEnrollResource extends Resource {
         Course course = courses.find(courseCode);
 
         if (step == 1) {
-            List<User> groupMembers = getGroupMembers(request);
+            Collection<User> groupMembers = getGroupMembers(request);
             int maxGroupSize = getMaxGroupSize(course);
             int minGroupSize = getMinGroupSize(course);
 
@@ -159,7 +159,7 @@ public class CourseEnrollResource extends Resource {
         }
 
         try {
-            List<User> members = (List<User>) session.getAttribute("projects.setup.members");
+            Collection<User> members = (Collection<User>) session.getAttribute("projects.setup.members");
             projectsBackend.setupProject(course, members);
 
             session.removeAttribute("projects.setup.course");
@@ -172,7 +172,7 @@ public class CourseEnrollResource extends Resource {
         }
     }
 
-    private List<User> getGroupMembers(HttpServletRequest request) {
+    private Collection<User> getGroupMembers(HttpServletRequest request) {
         String netId;
         int memberId = 1;
         Set<String> netIds = Sets.newHashSet();
@@ -182,11 +182,7 @@ public class CourseEnrollResource extends Resource {
         }
 
         Map<String, User> members = users.mapByNetIds(netIds);
-        List<User> sortedMembers = Lists.newArrayList();
-        for (String memberNetId : netIds) {
-            sortedMembers.add(members.get(memberNetId));
-        }
-        return sortedMembers;
+        return members.values();
     }
 
     public int getMinGroupSize(Course course) {


### PR DESCRIPTION
For me this fixed the crashes when adding an assistant with capital characters instead of lowercase characters. Not urgent because after cleaning your cookies you can reset the assistants again.