### PR TITLE
Fixed division by zero exception (if no groups for course)

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/backend/AssignmentStats.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/backend/AssignmentStats.java
@@ -21,7 +21,11 @@ public class AssignmentStats {
     }
     
     private int getPercentageFor(Predicate<? super Delivery> predicate) {
-        return getCountFor(predicate) * 100 / amountOfGroups();
+        int amountOfGroups = amountOfGroups();
+        if(amountOfGroups == 0){
+            return 0;
+        }
+        return getCountFor(predicate) * 100 / amountOfGroups;
     }
 
     /**


### PR DESCRIPTION
Not really urgent as TA's only have to review assignments if there are groups :see_no_evil: 