### PR TITLE
Fix bug with ssh key setup access violation

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/AccountResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/AccountResource.java
@@ -53,6 +53,14 @@ public class AccountResource extends Resource {
 		this.currentUser = currentUser;
 		this.users = users;
 	}
+	
+	private void verifyCanAccessPage(String netId) throws UnauthorizedException {
+		User account = users.findByNetId(netId);
+
+		if (!this.currentUser.isAdmin() && !this.currentUser.equals(account)) {
+			throw new UnauthorizedException();
+		}
+	}
 
 	@GET
 	public Response showPersonalUserPage() throws URISyntaxException {
@@ -65,11 +73,7 @@ public class AccountResource extends Resource {
 	public String showUserPage(@Context HttpServletRequest request, @PathParam("netId") String netId)
 			throws IOException, ApiError {
 
-		User account = users.findByNetId(netId);
-
-		if (!currentUser.isAdmin() && !currentUser.equals(account)) {
-			throw new UnauthorizedException();
-		}
+		verifyCanAccessPage(netId);
 
 		Map<String, Object> parameters = Maps.newHashMap();
 		parameters.put("user", currentUser);
@@ -84,6 +88,8 @@ public class AccountResource extends Resource {
 	@Path("{netId}/setup")
 	public String showNewSshKeyPage(@Context HttpServletRequest request, @PathParam("netId") String netId,
 			@QueryParam("error") String error) throws IOException {
+
+		verifyCanAccessPage(netId);
 
 		List<Locale> locales = Collections.list(request.getLocales());
 
@@ -101,11 +107,9 @@ public class AccountResource extends Resource {
 	public Response addNewKey(@PathParam("netId") String netId, @FormParam("name") String name,
 			@FormParam("contents") String contents) throws URISyntaxException, GitClientException {
 
-		User account = users.findByNetId(netId);
+		verifyCanAccessPage(netId);
 
-		if (!currentUser.isAdmin() && !currentUser.equals(account)) {
-			throw new UnauthorizedException();
-		}
+		User account = users.findByNetId(netId);
 
 		try {
 			backend.createNewSshKey(account, name, contents);
@@ -124,11 +128,9 @@ public class AccountResource extends Resource {
 	public Response deleteExistingKey(@PathParam("netId") String netId, @FormParam("name") String name)
 			throws URISyntaxException, GitClientException  {
 
-		User account = users.findByNetId(netId);
+		verifyCanAccessPage(netId);
 
-		if (!currentUser.isAdmin() && !currentUser.equals(account)) {
-			throw new UnauthorizedException();
-		}
+		User account = users.findByNetId(netId);
 
 		try {
 			backend.deleteSshKey(account, name);

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/AccountResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/AccountResource.java
@@ -54,12 +54,14 @@ public class AccountResource extends Resource {
 		this.users = users;
 	}
 	
-	private void verifyCanAccessPage(String netId) throws UnauthorizedException {
+	private User verifyCanAccessPage(String netId) throws UnauthorizedException {
 		User account = users.findByNetId(netId);
 
 		if (!this.currentUser.isAdmin() && !this.currentUser.equals(account)) {
 			throw new UnauthorizedException();
 		}
+		
+		return account;
 	}
 
 	@GET
@@ -73,7 +75,7 @@ public class AccountResource extends Resource {
 	public String showUserPage(@Context HttpServletRequest request, @PathParam("netId") String netId)
 			throws IOException, ApiError {
 
-		verifyCanAccessPage(netId);
+		User account = verifyCanAccessPage(netId);
 
 		Map<String, Object> parameters = Maps.newHashMap();
 		parameters.put("user", currentUser);
@@ -107,9 +109,7 @@ public class AccountResource extends Resource {
 	public Response addNewKey(@PathParam("netId") String netId, @FormParam("name") String name,
 			@FormParam("contents") String contents) throws URISyntaxException, GitClientException {
 
-		verifyCanAccessPage(netId);
-
-		User account = users.findByNetId(netId);
+		User account = verifyCanAccessPage(netId);
 
 		try {
 			backend.createNewSshKey(account, name, contents);
@@ -128,9 +128,7 @@ public class AccountResource extends Resource {
 	public Response deleteExistingKey(@PathParam("netId") String netId, @FormParam("name") String name)
 			throws URISyntaxException, GitClientException  {
 
-		verifyCanAccessPage(netId);
-
-		User account = users.findByNetId(netId);
+		User account = verifyCanAccessPage(netId);
 
 		try {
 			backend.deleteSshKey(account, name);


### PR DESCRIPTION
- Added a private method that can verify you can access the account page.
- Added the verification check in 'showNewSshKeyPage' as this was missing.