### PR TITLE
A bit more friendly warnings

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/backend/warnings/AbstractCommitWarningGenerator.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/backend/warnings/AbstractCommitWarningGenerator.java
@@ -31,4 +31,40 @@ public abstract class AbstractCommitWarningGenerator<T extends CommitWarning, A>
         return  gitServerClient.repositories()
             .retrieve(commit.getRepository().getRepositoryName());
     }
+
+    /**
+     * Get the property for a course
+     * @param commit commit for the group
+     * @param key key under which the property is stored
+     * @param def default value
+     * @return the value
+     */
+    protected String getProperty(final Commit commit, String key, final String def) {
+        final String value = commit.getRepository()
+            .getCourse()
+            .getProperties()
+            .get(key);
+        if(value == null) {
+            return def;
+        }
+        return value;
+    }
+
+    /**
+     * Get the property for a course
+     * @param commit commit for the group
+     * @param key key under which the property is stored
+     * @param def default value
+     * @return the value
+     */
+    protected String[] getProperty(final Commit commit, String key, final String[] def) {
+        final String value = commit.getRepository()
+            .getCourse()
+            .getProperties()
+            .get(key);
+        if(value == null) {
+            return def;
+        }
+        return value.split(",");
+    }
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/backend/warnings/IllegalFileWarningGenerator.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/backend/warnings/IllegalFileWarningGenerator.java
@@ -1,0 +1,94 @@
+package nl.tudelft.ewi.devhub.server.backend.warnings;
+
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.servlet.RequestScoped;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import nl.tudelft.ewi.devhub.server.database.entities.Commit;
+import nl.tudelft.ewi.devhub.server.database.entities.warnings.IllegalFileWarning;
+import nl.tudelft.ewi.devhub.server.web.models.GitPush;
+import nl.tudelft.ewi.git.client.GitServerClient;
+import nl.tudelft.ewi.git.client.Repository;
+import nl.tudelft.ewi.git.models.EntryType;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * @author Liam Clark
+ */
+@Slf4j
+@RequestScoped
+public class IllegalFileWarningGenerator extends AbstractCommitWarningGenerator<IllegalFileWarning, GitPush>
+implements CommitPushWarningGenerator<IllegalFileWarning> {
+
+
+    private static final String DEFAULT_EXTENSIONS_PROPERTY_KEY = "illegal.file-extensions";
+    private static final String DEFAULT_FOLDERS_PROPERTY_KEY = "illegal.folder-names";
+    private static final String[] DEFAULT_EXTENSIONS = {".iml",".class", ".bin", ".project", ".DS_Store"};
+    private static final String[] DEFAULT_FOLDERS = { ".idea/", ".metadata/", ".settings/",
+        ".project/", ".classpath/", "target/", "bin/", ".metadata/"};
+
+    private Repository repository;
+    private Commit commit;
+    private String[] illegalExtensions;
+    private String[] illegalFolders;
+
+    @Inject
+    public IllegalFileWarningGenerator(GitServerClient gitServerClient) {
+        super(gitServerClient);
+    }
+
+    @Override
+    @SneakyThrows
+    public Set<IllegalFileWarning> generateWarnings(Commit commit, GitPush attachment) {
+        log.debug("Start generating warnings for {} in {}", commit, this);
+        this.repository = getRepository(commit);
+        this.commit = commit;
+        this.illegalExtensions = getProperty(commit, DEFAULT_EXTENSIONS_PROPERTY_KEY, DEFAULT_EXTENSIONS);
+        this.illegalFolders = getProperty(commit, DEFAULT_FOLDERS_PROPERTY_KEY, DEFAULT_FOLDERS);
+
+        Set<IllegalFileWarning> warnings = Sets.newHashSet();
+        walkCommitStructure("",commit.getCommitId(),warnings);
+        log.debug("Finished generating warnings for {} in {}", commit, this);
+        return warnings;
+    }
+
+    @SneakyThrows
+    public void walkCommitStructure(String path, String commitId, Set<IllegalFileWarning> warnings){
+
+        if(folderViolation(path)){
+            IllegalFileWarning warning = new IllegalFileWarning();
+            warning.setFileName(path);
+            warning.setCommit(commit);
+            warnings.add(warning);
+        }
+
+        Map<String,EntryType> directory = repository.listDirectoryEntries(commitId, path);
+        directory.entrySet().stream()
+                .filter(entry -> entry.getValue().equals(EntryType.FOLDER))
+                .forEach(entry-> walkCommitStructure(path+entry.getKey(),commitId, warnings));
+
+        directory.entrySet().stream()
+                .filter(entry -> !entry.getValue().equals(EntryType.FOLDER))
+                .map(Map.Entry::getKey)
+                .filter(this::fileViolation)
+                .map(file -> {
+                    IllegalFileWarning warning = new IllegalFileWarning();
+                    warning.setCommit(commit);
+                    warning.setFileName(file);
+                    return warning;
+                })
+                .forEach(warnings::add);
+    }
+
+    private boolean fileViolation(String path){
+       return Stream.of(illegalExtensions).filter(path::endsWith).findAny().isPresent();
+    }
+
+    private boolean folderViolation(String path){
+        return Stream.of(illegalFolders).filter(path::endsWith).findAny().isPresent();
+    }
+}

--- a/src/main/java/nl/tudelft/ewi/devhub/server/backend/warnings/LargeCommitWarningGenerator.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/backend/warnings/LargeCommitWarningGenerator.java
@@ -3,6 +3,7 @@ package nl.tudelft.ewi.devhub.server.backend.warnings;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+import com.google.inject.servlet.RequestScoped;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import nl.tudelft.ewi.devhub.server.database.entities.Commit;
@@ -15,18 +16,25 @@ import nl.tudelft.ewi.git.models.DiffModel.DiffFile;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * @author Liam Clark
  */
 @Slf4j
+@RequestScoped
 public class LargeCommitWarningGenerator  extends AbstractCommitWarningGenerator<LargeCommitWarning, GitPush>
 implements CommitPushWarningGenerator<LargeCommitWarning> {
 
+
+    private static final String[] DEFAULT_EXTENSIONS = {".java", ".c", ".cpp", ".h", ".scala", ".js", ".html", ".css", ".less"};
     private static final int MAX_AMOUNT_OF_FILES = 10;
-    private static final int MAX_AMOUNT_OF_LINES_TOUCHED = 200;
+    private static final int MAX_AMOUNT_OF_LINES_TOUCHED = 500;
     private static final String MAX_FILES_PROPERTY = "warnings.max-touched-files";
     private static final String MAX_LINE_TOUCHED_PROPERTY = "warnings.max-line-edits";
+    private static final String COUNTED_EXTENSIONS_PROPERTY = "warnings.max-line-edits.types";
+
+    private String[] ext;
 
     @Inject
     public LargeCommitWarningGenerator(GitServerClient gitServerClient) {
@@ -38,6 +46,7 @@ implements CommitPushWarningGenerator<LargeCommitWarning> {
     public Set<LargeCommitWarning> generateWarnings(Commit commit, GitPush attachment) {
         log.debug("Start generating warnings for {} in {}", commit, this);
         List<DiffFile> diffs = getGitCommit(commit).diff().getDiffs();
+        this.ext = getProperty(commit, COUNTED_EXTENSIONS_PROPERTY, DEFAULT_EXTENSIONS);
 
         if(!commit.getMerge() && (tooManyFiles(diffs, commit) || tooManyLineChanges(diffs, commit))) {
             LargeCommitWarning warning = new LargeCommitWarning();
@@ -60,6 +69,8 @@ implements CommitPushWarningGenerator<LargeCommitWarning> {
         Course course = commit.getRepository().getCourse();
         int maxCountOfFiles = getIntegerProperty(course, MAX_LINE_TOUCHED_PROPERTY, MAX_AMOUNT_OF_LINES_TOUCHED);
         int count = (int) diffFiles.stream()
+                .filter(file ->
+                    file.isDeleted() ? fileViolation(file.getOldPath()) : fileViolation(file.getOldPath()))
                 .flatMap(diffFile -> diffFile.getContexts().stream())
                 .flatMap(context -> context.getLines().stream())
                 .filter(line -> line.isAdded() || line.isRemoved())
@@ -73,6 +84,10 @@ implements CommitPushWarningGenerator<LargeCommitWarning> {
             return Integer.valueOf(value);
         }
         return other;
+    }
+
+    private boolean fileViolation(final String path){
+        return Stream.of(ext).filter(path::endsWith).findAny().isPresent();
     }
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/warnings/IllegalFileWarning.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/warnings/IllegalFileWarning.java
@@ -1,0 +1,31 @@
+package nl.tudelft.ewi.devhub.server.database.entities.warnings;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import nl.tudelft.ewi.devhub.server.web.templating.Translator;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+/**
+ * Ignored files should not be commited.
+ * Furthermore, the .gitignore should not be removed or cleaned.
+ *
+ * @author Liam Clark
+ */
+@Data
+@Entity
+@DiscriminatorValue("illegal-file")
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class IllegalFileWarning extends FileWarning {
+
+    private static final String RESOURCE_KEY = "warning.committed-illegal-files";
+
+    @Override
+    public String getMessage(Translator translator) {
+        return translator.translate(RESOURCE_KEY, getFileName());
+    }
+
+}

--- a/src/main/resources/i18n/devhub_en.properties
+++ b/src/main/resources/i18n/devhub_en.properties
@@ -244,18 +244,20 @@ pull-request.open.message = Hey! You can merge the pull request by clicking the 
 pull-request.merging = Merging...
 pull-request.merged = Merged
 pull-request.failed-to-merge = Failed to merge
-pull-request.failed-to-merge.message = We can’t automatically merge this pull request due to merge conflicts.\
+pull-request.failed-to-merge.message = We can’t automatically merge this pull request due to merge conflicts. \
   Use the command line to resolve conflicts before continuing.
 pull-request.merged.message = It seems the branch is already merged into the master!
 pull-request.closed = Closed
 pull-request.closed.message = The pull request is closed and not merged into the master.
 
-warning.test-catches-throwables = Your test catches throwables. This is a bad practise.\
-  Concider to just let the exception be thrown if it occurs. Or if you wan't to ensure that an exception is thrown,\
+warning.test-catches-throwables = Your test catches throwables. This is a bad practise. \
+  Concider to just let the exception be thrown if it occurs. Or if you wan't to ensure that an exception is thrown, \
   use the ExcpectedException rule.
 warning.successive-build-failures = Your repository has successive build failures.\
   Your priority should be to fix the failing testcases.
-warning.committed-ignored-files = Remove binary (*.doc, *.bin), IDE specific (*.project, *.iml) and generated (*.class) files.\
+warning.committed-ignored-files = It's advised to not store binary files in the repository, because Git doesn't \
+  really version them well. Consider removing {0} from the repository.
+warning.committed-illegal-files = Remove binary (*.bin), IDE specific (*.project, *.iml) and generated (*.class) files. \
   The file/folder {0} should not be in the repository.
 warning.git-usage-warning = You are not using branches. Please push your commits to branches, \
   so other teammates can review your changes before they are being merged into the master branch.

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/IllegalFileWarningTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/IllegalFileWarningTest.java
@@ -1,7 +1,9 @@
 package nl.tudelft.ewi.devhub.server.backend.warnings;
 
+import com.google.common.collect.Maps;
+import nl.tudelft.ewi.devhub.server.database.entities.Course;
 import nl.tudelft.ewi.devhub.server.database.entities.Group;
-import nl.tudelft.ewi.devhub.server.database.entities.warnings.IgnoredFileWarning;
+import nl.tudelft.ewi.devhub.server.database.entities.warnings.IllegalFileWarning;
 import nl.tudelft.ewi.git.client.Branch;
 import nl.tudelft.ewi.git.client.Commit;
 import nl.tudelft.ewi.git.client.GitServerClient;
@@ -29,42 +31,45 @@ import static org.mockito.Mockito.when;
  * @author Jan-Willem Gmelig Meyling
  */
 @RunWith(MockitoJUnitRunner.class)
-public class IgnoredFileWarningTest {
+public class IllegalFileWarningTest {
 
     private final static String COMMIT_ID = "abcd";
     private final Map<String,EntryType> directory1 = new HashMap<>();
 
     @Mock private nl.tudelft.ewi.devhub.server.database.entities.Commit commitEntity;
     @Mock private Group group;
+    @Mock private Course course;
     @Mock private Commit commit;
     @Mock private Repository repository;
     @Mock private Repositories repositories;
     @Mock private GitServerClient gitServerClient;
     @Mock private Branch branch;
     @Mock private CommitModel commitModel;
-    @InjectMocks  private IgnoredFileWarningGenerator generator;
+    @InjectMocks  private IllegalFileWarningGenerator generator;
 
-    private IgnoredFileWarning warning;
+    private IllegalFileWarning warning;
 
     @Before
     public void beforeTest() throws Exception {
         when(commitEntity.getCommitId()).thenReturn(COMMIT_ID);
         when(commitEntity.getRepository()).thenReturn(group);
         when(group.getRepositoryName()).thenReturn("abc");
+        when(group.getCourse()).thenReturn(course);
+        when(course.getProperties()).thenReturn(Maps.newHashMap());
         when(gitServerClient.repositories()).thenReturn(repositories);
         when(repositories.retrieve(anyString())).thenReturn(repository);
         when(repository.listDirectoryEntries(COMMIT_ID,"")).thenReturn(directory1);
 
         directory1.clear();
 
-        warning = new IgnoredFileWarning();
+        warning = new IllegalFileWarning();
         warning.setCommit(commitEntity);
     }
 
     @Test
     public void TestIngoredFile(){
         directory1.put("types.class",EntryType.TEXT);
-        Collection<IgnoredFileWarning> warnings = generator.generateWarnings(commitEntity, null);
+        Collection<IllegalFileWarning> warnings = generator.generateWarnings(commitEntity, null);
         warning.setFileName("types.class");
         assertEquals(warning,warnings.stream().findFirst().get());
     }
@@ -72,8 +77,8 @@ public class IgnoredFileWarningTest {
     @Test
     public void TestNotIngoredFile(){
         directory1.put("types.java",EntryType.TEXT);
-        Collection<IgnoredFileWarning> warnings = generator.generateWarnings(commitEntity, null);
-        IgnoredFileWarning warning = new IgnoredFileWarning();
+        Collection<IllegalFileWarning> warnings = generator.generateWarnings(commitEntity, null);
+        IllegalFileWarning warning = new IllegalFileWarning();
         warning.setFileName("types.java");
         assertEquals(Collections.emptySet(), warnings);
     }
@@ -81,10 +86,9 @@ public class IgnoredFileWarningTest {
     @Test
     public void TestIgnoredFolder(){
         directory1.put("bin/",EntryType.FOLDER);
-        Collection<IgnoredFileWarning> warnings = generator.generateWarnings(commitEntity,null);
-        IgnoredFileWarning warning = new IgnoredFileWarning();
+        Collection<IllegalFileWarning> warnings = generator.generateWarnings(commitEntity,null);
         warning.setFileName("bin/");
-        assertEquals(warning,warnings.stream().findFirst().get());
+        assertEquals(warning ,warnings.stream().findFirst().get());
     }
 
 }


### PR DESCRIPTION
* Only count source folders for large commits
* Show ignored file warning only on the commits in which the file is changed
* Introduction for illegal files / folders, which basically was the old ignored file warning, but then for just .class and bin files, not doc etc.
* Made the warning generators more configurable from the DB