### PR TITLE
Build server register resource, fixes #263

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,11 @@
 			<artifactId>jbcrypt</artifactId>
 			<version>0.3m</version>
 		</dependency>
+		<dependency>
+			<groupId>com.jcraft</groupId>
+			<artifactId>jsch</artifactId>
+			<version>0.1.53</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/BuildServer.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/BuildServer.java
@@ -1,6 +1,8 @@
 package nl.tudelft.ewi.devhub.server.database.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -8,11 +10,11 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
 
 @Data
 @Entity
 @Table(name = "build_servers")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class BuildServer {
 	
 	@Id
@@ -20,15 +22,15 @@ public class BuildServer {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private long id;
 	
-	@NotNull
+	@NotEmpty
 	@Column(name = "name")
 	private String name;
-	
-	@NotNull
+
+	@NotEmpty
 	@Column(name = "secret")
 	private String secret;
 
-	@NotNull
+	@NotEmpty
 	@Column(name = "host")
 	private String host;
 

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/BuildServerRegistrationResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/BuildServerRegistrationResource.java
@@ -1,0 +1,123 @@
+package nl.tudelft.ewi.devhub.server.web.resources;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import com.google.inject.servlet.RequestScoped;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.KeyPair;
+import com.jcraft.jsch.Signature;
+import lombok.SneakyThrows;
+import nl.tudelft.ewi.devhub.server.backend.BuildsBackend;
+import nl.tudelft.ewi.devhub.server.database.entities.BuildServer;
+import nl.tudelft.ewi.devhub.server.web.errors.ApiError;
+import nl.tudelft.ewi.git.models.SshKeyModel;
+import nl.tudelft.ewi.git.models.UserModel;
+import nl.tudelft.ewi.git.web.api.GroupsApi;
+import nl.tudelft.ewi.git.web.api.KeysApi;
+import nl.tudelft.ewi.git.web.api.UserApi;
+import nl.tudelft.ewi.git.web.api.UsersApi;
+import org.jboss.resteasy.plugins.validation.hibernate.ValidateRequest;
+import org.jboss.resteasy.util.Base64;
+
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.function.Predicate;
+
+/**
+ * @author Jan-Willem Gmelig Meyling
+ */
+@RequestScoped
+@Path("build-servers")
+@ValidateRequest
+@Produces(MediaType.TEXT_HTML + Resource.UTF8_CHARSET)
+public class BuildServerRegistrationResource extends Resource {
+
+	public static final String BUILD_SERVERS_GROUP = "@build-servers";
+	private final JSch jSch;
+	private final BuildsBackend backend;
+	private final UsersApi usersApi;
+	private final GroupsApi groupsApi;
+
+	@Inject
+	public BuildServerRegistrationResource(BuildsBackend backend, GroupsApi groupsApi, UsersApi usersApi, JSch jSch) {
+		this.backend = backend;
+		this.usersApi = usersApi;
+		this.groupsApi = groupsApi;
+		this.jSch = jSch;
+	}
+
+	/**
+	 * Hook for automatically registering {@link BuildServer Build servers}.
+	 * The Build Server may send this request to register itself as build server.
+	 *
+	 * It should sign the request using its private key, which is validated against
+	 * the public key under the build server name in the git server. This ensures
+	 * that the build server key has read access to the repositories and that the
+	 * build server is allowed to join the pool.
+	 *
+	 * @param buildServer Build Server object, containing name, secret and hostname.
+	 * @param signatureString The signature of the secret.
+	 *
+	 * @throws IOException If an I/O error occurs.
+	 * @throws ApiError If an API error occurs.
+	 * @throws InternalServerErrorException If the build-server group could not be found on the git server.
+	 * @throws NotAuthorizedException If the build server is not authorized.
+	 */
+	@POST
+	@Path("register")
+	@Transactional
+	@Consumes(MediaType.APPLICATION_JSON)
+	public void registerBuildServer(@Valid BuildServer buildServer, @HeaderParam("Signature") String signatureString) throws IOException, ApiError, InternalServerErrorException, NotAuthorizedException {
+		byte[] signature = Base64.decode(signatureString);
+
+		class SignatureVerifier implements Predicate<Signature> {
+			@Override
+			@SneakyThrows
+			public boolean test(Signature verifier) {
+				verifier.update(buildServer.getSecret().getBytes());
+				return verifier.verify(signature);
+			}
+		}
+
+		checkBuildServerMembership(buildServer);
+		KeysApi keysApi = usersApi.getUser(buildServer.getName()).keys();
+
+		if (!keysApi.listSshKeys().stream()
+			.map(this::getKeyPair)
+			.map(KeyPair::getVerifier)
+			.anyMatch(new SignatureVerifier())) {
+			throw new NotAuthorizedException("Cannot verify signature of build server: " + buildServer.getName());
+		}
+
+		backend.addBuildServer(buildServer);
+	}
+
+	private void checkBuildServerMembership(BuildServer buildServer) {
+		UserApi userApi = usersApi.getUser(buildServer.getName());
+		UserModel userModel = userApi.get();
+
+		try {
+			if (!groupsApi.getGroup(BUILD_SERVERS_GROUP).listMembers().contains(userModel)) {
+				throw new NotAuthorizedException(String.format("Build server %s is not a member of the %s group", buildServer.getName(), BUILD_SERVERS_GROUP));
+			}
+		}
+		catch (NotFoundException e) {
+			throw new InternalServerErrorException("Build-servers group could not be found: " + e.getMessage(), e);
+		}
+	}
+
+	@SneakyThrows
+	private KeyPair getKeyPair(SshKeyModel sshKeyModel) {
+		return KeyPair.load(jSch, null, sshKeyModel.getContents().getBytes());
+	}
+
+}

--- a/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/BuildServerRegistrationTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/BuildServerRegistrationTest.java
@@ -1,0 +1,141 @@
+package nl.tudelft.ewi.devhub.server.web.resources;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.KeyPair;
+import nl.tudelft.ewi.devhub.server.backend.BuildsBackend;
+import nl.tudelft.ewi.devhub.server.database.entities.BuildServer;
+import nl.tudelft.ewi.git.models.GroupModel;
+import nl.tudelft.ewi.git.models.SshKeyModel;
+import nl.tudelft.ewi.git.models.UserModel;
+import nl.tudelft.ewi.git.web.api.GroupApi;
+import nl.tudelft.ewi.git.web.api.GroupsApi;
+import nl.tudelft.ewi.git.web.api.KeysApi;
+import nl.tudelft.ewi.git.web.api.UserApi;
+import nl.tudelft.ewi.git.web.api.UsersApi;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
+import java.io.ByteArrayOutputStream;
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Jan-Willem Gmelig Meyling
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BuildServerRegistrationTest {
+
+	private static final String NOT_A_BUILDSERVER = "not-a-build-server";
+	private static final String BUILD_SERVER_NAME = "build-server-1";
+	private static final String BUILD_SERVER_HOST = "localhost";
+	private static final String BUILD_SERVER_SECRET = "top-secret";
+
+	@Spy JSch jSch = new JSch();
+	@Mock UsersApi usersApi;
+	@Mock UserApi userApi;
+	@Mock KeysApi keysApi;
+	@Mock GroupsApi groupsApi;
+	@Mock GroupApi groupApi;
+	@Mock BuildsBackend buildsBackend;
+	@InjectMocks BuildServerRegistrationResource buildServerRegistrationResource;
+
+	KeyPair valid;
+	KeyPair invalid;
+	GroupModel groupModel;
+
+	@Before
+	public void prepareBuildServerKey() throws JSchException {
+		valid = KeyPair.genKeyPair(jSch, KeyPair.RSA);
+		invalid = KeyPair.genKeyPair(jSch, KeyPair.RSA);
+
+		SshKeyModel sshKeyModel = new SshKeyModel();
+		ByteArrayOutputStream bas = new ByteArrayOutputStream();
+		valid.writePublicKey(bas, BUILD_SERVER_NAME);
+		sshKeyModel.setName(BUILD_SERVER_NAME);
+		sshKeyModel.setContents(bas.toString());
+
+		UserModel userModel = new UserModel();
+		userModel.setName(BUILD_SERVER_NAME);
+		userModel.setKeys(Collections.singleton(sshKeyModel));
+
+		groupModel = new GroupModel();
+		groupModel.setName(BuildServerRegistrationResource.BUILD_SERVERS_GROUP);
+		groupModel.setMembers(Collections.singleton(userModel));
+
+		when(usersApi.getUser(BUILD_SERVER_NAME)).thenReturn(userApi);
+		when(userApi.get()).thenReturn(userModel);
+		when(userApi.keys()).thenReturn(keysApi);
+
+		when(groupsApi.getGroup(BuildServerRegistrationResource.BUILD_SERVERS_GROUP)).thenReturn(groupApi);
+		when(groupApi.getGroup()).thenReturn(groupModel);
+		when(groupApi.listMembers()).thenReturn(groupModel.getMembers());
+
+		when(keysApi.listSshKeys()).thenReturn(Collections.singleton(sshKeyModel));
+	}
+
+	@Test
+	public void testRegisterBuildServer() throws Exception {
+		BuildServer buildServer = new BuildServer();
+		buildServer.setHost(BUILD_SERVER_HOST);
+		buildServer.setName(BUILD_SERVER_NAME);
+		buildServer.setSecret(BUILD_SERVER_SECRET);
+
+		String signature = getSignature(valid, BUILD_SERVER_SECRET);
+		buildServerRegistrationResource.registerBuildServer(buildServer, signature);
+	}
+
+	@Test(expected = NotAuthorizedException.class)
+	public void testRegisterBuildServerWithInvalidSignature() throws Exception {
+		BuildServer buildServer = new BuildServer();
+		buildServer.setHost(BUILD_SERVER_HOST);
+		buildServer.setName(BUILD_SERVER_NAME);
+		buildServer.setSecret(BUILD_SERVER_SECRET);
+
+		String signature = getSignature(invalid, BUILD_SERVER_SECRET);
+		buildServerRegistrationResource.registerBuildServer(buildServer, signature);
+	}
+
+	@Test(expected = NotAuthorizedException.class)
+	public void testNotRegisterBuildServer() throws Exception {
+		UserModel userModel = new UserModel();
+		userModel.setName(NOT_A_BUILDSERVER);
+
+		UserApi userApi = mock(UserApi.class);
+		when(usersApi.getUser(NOT_A_BUILDSERVER)).thenReturn(userApi);
+		when(userApi.get()).thenReturn(userModel);
+
+		BuildServer buildServer = new BuildServer();
+		buildServer.setHost(BUILD_SERVER_HOST);
+		buildServer.setName(NOT_A_BUILDSERVER);
+		buildServer.setSecret(BUILD_SERVER_SECRET);
+
+		String signatue = getSignature(valid, BUILD_SERVER_SECRET);
+		buildServerRegistrationResource.registerBuildServer(buildServer, signatue);
+	}
+
+	@Test(expected = InternalServerErrorException.class)
+	public void internalServerErrorOnGroupNotFound() throws Exception {
+		reset(groupsApi);
+		when(groupsApi.getGroup(BuildServerRegistrationResource.BUILD_SERVERS_GROUP))
+			.thenThrow(new NotFoundException("Build server not found"));
+
+		testRegisterBuildServer();
+	}
+
+	private static String getSignature(KeyPair keyPair, String secret) {
+		byte[] signature = keyPair.getSignature(secret.getBytes());
+		return Base64.encodeBase64String(signature);
+	}
+
+}


### PR DESCRIPTION
Implements an API resource where build servers can register. In order to be registered we have to publish the public key for the build server to the Git server and assign the user to the `@build-servers` group.

So the steps are as follows:
* Create an SSH key for the build server
* Store the public key on the git server as `build-server-name.pub`
* Give the build server read access, by adding the build server to the build servers group (`@build-servers = build-server-name`). (This is a manual step, but technically multiple build servers can use the same name / SSH key combination).
* Start the build server and trigger the hook on Devhub.

The request contains the following information:

```json
{
   "name": "build-server-name",
   "secret": "build-server-secret",
   "host": "http://localhost:8082"
}
```

Furthermore, a signature will be sent which allows Devhub to check if the build server actually has the private key for the SSH key. The secret and name are used for the Basic authentication when sending build responses and target files to Devhub.

Fixes #263 