### PR TITLE
Batch releases, fixes #99

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Assignment.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Assignment.java
@@ -84,6 +84,9 @@ public class Assignment implements Comparable<Assignment>, Base {
     @Temporal(TemporalType.TIMESTAMP)
     private Date dueDate;
 
+    @Column(name="released")
+    private boolean gradesReleased;
+
     @Override
     public int compareTo(Assignment o) {
         return ComparisonChain.start()

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/AssignmentsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/AssignmentsResource.java
@@ -312,7 +312,8 @@ public class AssignmentsResource extends Resource {
                                    @PathParam("assignmentId") long assignmentId,
                                    @FormParam("name") String name,
                                    @FormParam("summary") String summary,
-                                   @FormParam("due-date") String dueDate) {
+                                   @FormParam("due-date") String dueDate,
+                                   @FormParam("release") Boolean release) {
 
         CourseEdition course = courses.find(courseCode, editionCode);
 
@@ -323,7 +324,7 @@ public class AssignmentsResource extends Resource {
         Assignment assignment = assignmentsDAO.find(course, assignmentId);
         assignment.setName(name);
         assignment.setSummary(summary);
-
+        assignment.setGradesReleased(release);
 
         if(!Strings.isNullOrEmpty(dueDate)) {
             SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DATE_FORMAT);

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/AssignmentsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/AssignmentsResource.java
@@ -313,7 +313,7 @@ public class AssignmentsResource extends Resource {
                                    @FormParam("name") String name,
                                    @FormParam("summary") String summary,
                                    @FormParam("due-date") String dueDate,
-                                   @FormParam("release") Boolean release) {
+                                   @FormParam("release") String release) {
 
         CourseEdition course = courses.find(courseCode, editionCode);
 
@@ -325,9 +325,9 @@ public class AssignmentsResource extends Resource {
         assignment.setName(name);
         assignment.setSummary(summary);
 
-        if(release != null) {
-            assignment.setGradesReleased(release);
-        }
+        //a little bit ugly, form params don't work nicely with checkboxes.
+        boolean releaseStatus = release != null && release.equals("on");
+        assignment.setGradesReleased(releaseStatus);
 
         if(!Strings.isNullOrEmpty(dueDate)) {
             SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DATE_FORMAT);

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/AssignmentsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/AssignmentsResource.java
@@ -324,7 +324,10 @@ public class AssignmentsResource extends Resource {
         Assignment assignment = assignmentsDAO.find(course, assignmentId);
         assignment.setName(name);
         assignment.setSummary(summary);
-        assignment.setGradesReleased(release);
+
+        if(release != null) {
+            assignment.setGradesReleased(release);
+        }
 
         if(!Strings.isNullOrEmpty(dueDate)) {
             SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DATE_FORMAT);

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResource.java
@@ -351,7 +351,6 @@ public class ProjectAssignmentsResource extends Resource {
 
         try {
             deliveriesBackend.review(delivery, review);
-            reviewMailer.sendReviewMail(delivery);
         }
         catch (Exception e){
             throw new ApiError("error.could-not-review", e);

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResource.java
@@ -128,6 +128,7 @@ public class ProjectAssignmentsResource extends Resource {
         Map<String, Object> parameters = getBaseParameters();
         parameters.put("repository", repositoryModel);
         parameters.put("deliveries", deliveries);
+        parameters.put("submittedState", Delivery.State.SUBMITTED);
 
         List<Locale> locales = Collections.list(request.getLocales());
         return display(templateEngine.process("courses/assignments/group-assignments.ftl", locales, parameters));

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResource.java
@@ -180,9 +180,9 @@ public class ProjectAssignmentsResource extends Resource {
      * @param assignment the assignment we are showing the grade for.
      * @return  whether the current user can see the grade yet.
      */
-    private boolean canSeeGrade(Assignment assignment) {
+    protected boolean canSeeGrade(Assignment assignment) {
         CourseEdition edition = group.getCourseEdition();
-        return (currentUser.isAdmin() || currentUser.isAssisting(edition) )  || assignment.isGradesReleased();
+        return currentUser.isAdmin() || currentUser.isAssisting(edition) || assignment.isGradesReleased();
     }
 
     /**

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResource.java
@@ -109,6 +109,7 @@ public class ProjectAssignmentsResource extends Resource {
 		parameters.put("group", group);
 		parameters.put("course", group.getCourseEdition());
 		parameters.put("repositoryEntity", repositoryEntity);
+        parameters.put("submittedState", Delivery.State.SUBMITTED);
 		return parameters;
 	}
 
@@ -128,7 +129,6 @@ public class ProjectAssignmentsResource extends Resource {
         Map<String, Object> parameters = getBaseParameters();
         parameters.put("repository", repositoryModel);
         parameters.put("deliveries", deliveries);
-        parameters.put("submittedState", Delivery.State.SUBMITTED);
 
         List<Locale> locales = Collections.list(request.getLocales());
         return display(templateEngine.process("courses/assignments/group-assignments.ftl", locales, parameters));

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResource.java
@@ -78,7 +78,6 @@ public class ProjectAssignmentsResource extends Resource {
     private final Deliveries deliveries;
     private final DeliveriesBackend deliveriesBackend;
     private final Assignments assignments;
-    private final ReviewMailer reviewMailer;
 
     @Inject
     public ProjectAssignmentsResource(final TemplateEngine templateEngine,
@@ -89,8 +88,7 @@ public class ProjectAssignmentsResource extends Resource {
                                       final RepositoriesApi repositoriesApi,
                                       final DeliveriesBackend deliveriesBackend,
                                       final Assignments assignments,
-                                      final Commits commits,
-                                      final ReviewMailer reviewMailer) {
+                                      final Commits commits) {
 
         this.templateEngine = templateEngine;
         this.group = group;
@@ -101,7 +99,6 @@ public class ProjectAssignmentsResource extends Resource {
         this.repositoriesApi = repositoriesApi;
         this.deliveriesBackend = deliveriesBackend;
         this.assignments = assignments;
-        this.reviewMailer = reviewMailer;
         this.commits = commits;
     }
 

--- a/src/main/resources/changelog.xml
+++ b/src/main/resources/changelog.xml
@@ -876,7 +876,9 @@
 	
 	<changeSet id="add_assignment_release" author="Liam Clark">
 		<addColumn tableName="assignments">
-			<column name="released" type="boolean" defaultValue="true"/>
+			<column name="released" type="boolean" defaultValue="true">
+				<constraints nullable="false"/>
+			</column>
 		</addColumn>
 	</changeSet>
 

--- a/src/main/resources/changelog.xml
+++ b/src/main/resources/changelog.xml
@@ -873,5 +873,11 @@
 			</column>
 		</createTable>
 	</changeSet>
+	
+	<changeSet id="add_assignment_release" author="Liam Clark">
+		<addColumn tableName="assignments">
+			<column name="released" type="boolean" defaultValue="true"/>
+		</addColumn>
+	</changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/i18n/devhub_en.properties
+++ b/src/main/resources/i18n/devhub_en.properties
@@ -172,6 +172,7 @@ assignment.submissions = Submissions
 assignment.groups = Groups
 assignment.no-deliveries = No deliveries for assignment yet
 assignment.create = Create assignment
+assignment.release = Release grades
 assignment.go-back-to-assignment = Go back to assignment
 assignment.no-submission.assistant = This group has not made a submission for this assignment yet.
 assignment.no-submission.member = You have not made a submission for this assignment yet.

--- a/src/main/resources/templates/components/delivery.ftl
+++ b/src/main/resources/templates/components/delivery.ftl
@@ -69,9 +69,8 @@
     </ul>
     [/#if]
 
-
     [#assign review = delivery.getReview()!]
-    [#if review?? && review?has_content && (review.getGrade()?? || review.getCommentary()??)]
+    [#if review?? && seeGrade && review?has_content && (review.getGrade()?? || review.getCommentary()??)]
     <blockquote>
         <dl>
             [#if review.getGrade()??]

--- a/src/main/resources/templates/components/delivery.ftl
+++ b/src/main/resources/templates/components/delivery.ftl
@@ -22,8 +22,11 @@
     [/#if]
 [/#macro]
 
-[#macro deliveryStateLabel delivery]
+[#macro deliveryStateLabel delivery seesGrade]
     [#assign state = delivery.getState()]
+    [#if !seesGrade]
+        [#assign state = submittedState]
+    [/#if]
     <span class="label label-${state.style}" data-toggle="tooltip" title="${i18n.translate(state.messageTranslationKey)}">
         ${i18n.translate(state.translationKey)}
     </span>
@@ -37,7 +40,7 @@
             [@buildLabel delivery group states/]
         [/#if]
 
-        [@deliveryStateLabel delivery/]
+        [@deliveryStateLabel delivery seeGrade/]
     </div>
 
     <dl>

--- a/src/main/resources/templates/courses/assignments/create-assignment.ftl
+++ b/src/main/resources/templates/courses/assignments/create-assignment.ftl
@@ -44,7 +44,7 @@
     <div class="form-group">
         <label for="release" class="col-sm-2 control-label">${i18n.translate("assignment.release")}</label>
         <div class="col-sm-10">
-            <input type="checkbox" class="form-control" id="release">
+            <input type="checkbox" class="form-control" name="release" id="release">
         </div>
     </div>
     [/#if]

--- a/src/main/resources/templates/courses/assignments/create-assignment.ftl
+++ b/src/main/resources/templates/courses/assignments/create-assignment.ftl
@@ -41,6 +41,13 @@
     </div>
 
     <div class="form-group">
+        <label for="release" class="col-sm-2 control-label">Release grades</label>
+        <div class="col-sm-10">
+            <input type="checkbox" class="form-control" id="release">
+        </div>
+    </div>
+
+    <div class="form-group">
         <label for="name" class="col-sm-2 control-label">${i18n.translate("course.control.assignment-name")}</label>
         <div class="col-sm-10">
         [#if assignment?exists]

--- a/src/main/resources/templates/courses/assignments/create-assignment.ftl
+++ b/src/main/resources/templates/courses/assignments/create-assignment.ftl
@@ -40,12 +40,14 @@
         </div>
     </div>
 
+    [#if assignment?exists]
     <div class="form-group">
-        <label for="release" class="col-sm-2 control-label">Release grades</label>
+        <label for="release" class="col-sm-2 control-label">${i18n.translate("assignment.release")}</label>
         <div class="col-sm-10">
             <input type="checkbox" class="form-control" id="release">
         </div>
     </div>
+    [/#if]
 
     <div class="form-group">
         <label for="name" class="col-sm-2 control-label">${i18n.translate("course.control.assignment-name")}</label>

--- a/src/main/resources/templates/courses/assignments/create-assignment.ftl
+++ b/src/main/resources/templates/courses/assignments/create-assignment.ftl
@@ -44,7 +44,7 @@
     <div class="form-group">
         <label for="release" class="col-sm-2 control-label">${i18n.translate("assignment.release")}</label>
         <div class="col-sm-10">
-            <input type="checkbox" class="form-control" name="release" id="release">
+            <input type="checkbox" class="form-control" name="release" id="release" [#if assignment.isGradesReleased()]checked [/#if]>
         </div>
     </div>
     [/#if]

--- a/src/main/resources/templates/courses/assignments/group-assignments.ftl
+++ b/src/main/resources/templates/courses/assignments/group-assignments.ftl
@@ -41,6 +41,7 @@
                 <tbody>
                 [#if assignments?? && assignments?has_content]
                     [#list assignments as assignment]
+                    [#assign showGrade = assignment.isGradesReleased() || user.isAdmin() || user.isAssisting(course)]
                     [#assign delivery = deliveries.getLastDelivery(assignment, group)!]
                     <tr>
                         <td>
@@ -61,7 +62,7 @@
                             [/#if]
                         </td>
                         <td>
-                            [#if delivery?has_content && delivery.getReview()??]
+                            [#if delivery?has_content && delivery.getReview()?? && showGrade]
                             [#assign review = delivery.getReview()]
                             ${review.getGrade()!"-"}
                             [/#if]
@@ -88,6 +89,9 @@
                                 [/#if]
 
                                 [#assign state = delivery.getState()]
+                                [#if !showGrade]
+                                    [#assign state = submittedState]
+                                [/#if]
 	                            <span class="label label-${state.style}" data-toggle="tooltip" title="${i18n.translate(state.messageTranslationKey)}">
                                     ${i18n.translate(state.translationKey)}
 	                            </span>

--- a/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResourceTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResourceTest.java
@@ -1,0 +1,65 @@
+package nl.tudelft.ewi.devhub.server.web.resources;
+
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import nl.tudelft.ewi.devhub.server.database.entities.Assignment;
+import nl.tudelft.ewi.devhub.server.database.entities.CourseEdition;
+import nl.tudelft.ewi.devhub.server.database.entities.Group;
+import nl.tudelft.ewi.devhub.server.database.entities.User;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProjectAssignmentsResourceTest {
+    @Mock
+    private CourseEdition edition;
+
+    @Mock
+    private Group group;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private Assignment assignment;
+
+    private ProjectAssignmentsResource resource;
+
+    @Before
+    public void setUp() {
+        resource = new ProjectAssignmentsResource(null, user, group, null, null, null, null, null, null);
+        Mockito.when(group.getCourseEdition()).thenReturn(edition);
+    }
+
+    @Test
+    public void testCanSeeGrade() {
+        Mockito.when(assignment.isGradesReleased()).thenReturn(true);
+        assertTrue(resource.canSeeGrade(assignment));
+    }
+
+    @Test
+    public void testNotReleasedStudent() {
+        Mockito.when(assignment.isGradesReleased()).thenReturn(false);
+        assertFalse(resource.canSeeGrade(assignment));
+    }
+
+    @Test
+    public void testNotReleasedAdmin() {
+        Mockito.when(assignment.isGradesReleased()).thenReturn(false);
+        Mockito.when(user.isAdmin()).thenReturn(true);
+        assertTrue(resource.canSeeGrade(assignment));
+    }
+
+    @Test
+    public void testNotReleasedTA() {
+        Mockito.when(assignment.isGradesReleased()).thenReturn(false);
+        Mockito.when(user.isAssisting(edition)).thenReturn(true);
+        assertTrue(resource.canSeeGrade(assignment));
+    }
+}


### PR DESCRIPTION
Grades were always released as soon as the ta filled them in, we want to manage this and release the grades at the same time, this pr fixes that.

We no longer send an email when the grade is uploaded and the email field is completely gone now from the ProjectAssignmentResource.

The ProjectAssignmentResource checks wether the user is a TA or admin and always shows them the grade.

If the user is a student he will only see it once the assignment grades have been released. 

Potential problem it adds a flag which is checked in the freemarker template, this flag get's used in the delivery render macro, if it get's called anywhere else this will break the other call site. 

@JWGmeligMeyling do you know about such another callsite or a nicer way to do this?

finally the edit assignment form shows a release grade check mark if the assignment already exists, because making an assignment that immediately releases the grades makes little sense.