### PR TITLE
remove duplicate slash in freemarker template

### DIFF
--- a/src/main/resources/templates/project-pull.ftl
+++ b/src/main/resources/templates/project-pull.ftl
@@ -181,7 +181,7 @@ $(function() {
         var label = $('span', btn).html('${i18n.translate("pull-request.merging")}');
 		var message = $('#merge-message');
 
-        $.post("${pullRequest.getURI()}/merge")
+        $.post("${pullRequest.getURI()}merge")
             .done(function(res) {
                 if(res.success) {
                     label.html('${i18n.translate("pull-request.merged")}');


### PR DESCRIPTION
a duplicate slash stopped the merging of pr's