### PR TITLE
escape branches with /'s in the branch overview ui, fixes #289

### DIFF
--- a/src/main/resources/templates/project-view.ftl
+++ b/src/main/resources/templates/project-view.ftl
@@ -54,7 +54,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                     [#list repository.getBranches() as b ]
-                        <li><a href="${repositoryEntity.getURI()}branch/${b.getSimpleName()}" style="text-align:right;">
+                        <li><a href="${repositoryEntity.getURI()}branch/${b.name?url('UTF-8')}" style="text-align:right;">
                         ${b.getSimpleName()}
                             [#if b.isBehind() || b.isAhead() ]
                                 <span class="text-success octicon octicon-arrow-up"></span>


### PR DESCRIPTION
We can escape the url in freemarker template