### PR TITLE
Pullrequest template fixes

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectPullResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectPullResource.java
@@ -52,6 +52,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectResource.java
@@ -61,7 +61,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -195,7 +197,17 @@ public abstract class AbstractProjectResource<RepoType extends RepositoryEntity>
 		}
 
 		List<Locale> locales = Collections.list(request.getLocales());
-		return display(templateEngine.process("project-view.ftl", locales, parameters));
+		Response response =  display(templateEngine.process("project-view.ftl", locales, parameters));
+		
+		CacheControl cc = new CacheControl();
+		cc.setNoStore(true);
+		cc.setNoCache(true);
+		cc.setMaxAge(0);
+		cc.setPrivate(true);
+		
+		response.getHeaders().add(HttpHeaders.CACHE_CONTROL, cc.toString());
+		return response;
+		
 	}
 
 	protected List<String> getCommitIds(CommitSubList commits) {

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectResource.java
@@ -44,6 +44,7 @@ import nl.tudelft.ewi.git.web.api.RepositoriesApi;
 import nl.tudelft.ewi.git.web.api.RepositoryApi;
 
 import org.hibernate.validator.constraints.NotEmpty;
+import org.jboss.resteasy.annotations.cache.Cache;
 import org.jboss.resteasy.plugins.validation.hibernate.ValidateRequest;
 
 import javax.persistence.EntityNotFoundException;
@@ -159,6 +160,7 @@ public abstract class AbstractProjectResource<RepoType extends RepositoryEntity>
 	}
 
 	@GET
+	@Cache(noStore = true)
 	@Path("/branch/{branchName}")
 	@Transactional
 	public Response showBranchOverview(@Context HttpServletRequest request,
@@ -197,16 +199,7 @@ public abstract class AbstractProjectResource<RepoType extends RepositoryEntity>
 		}
 
 		List<Locale> locales = Collections.list(request.getLocales());
-		Response response =  display(templateEngine.process("project-view.ftl", locales, parameters));
-		
-		CacheControl cc = new CacheControl();
-		cc.setNoStore(true);
-		cc.setNoCache(true);
-		cc.setMaxAge(0);
-		cc.setPrivate(true);
-		
-		response.getHeaders().add(HttpHeaders.CACHE_CONTROL, cc.toString());
-		return response;
+		return display(templateEngine.process("project-view.ftl", locales, parameters));		
 		
 	}
 

--- a/src/main/resources/i18n/devhub_en.properties
+++ b/src/main/resources/i18n/devhub_en.properties
@@ -244,7 +244,7 @@ pull-request.open.message = Hey! You can merge the pull request by clicking the 
 pull-request.merging = Merging...
 pull-request.merged = Merged
 pull-request.failed-to-merge = Failed to merge
-pull-request.failed-to-merge.message = We can\\''t automatically merge this pull request due to merge conflicts. \
+pull-request.failed-to-merge.message = We can''t automatically merge this pull request due to merge conflicts. \
   Use the command line to resolve conflicts before continuing.
 pull-request.merged.message = It seems the branch is already merged into the master!
 pull-request.merged.message = The pull request is closed and merged into the master.

--- a/src/main/resources/i18n/devhub_en.properties
+++ b/src/main/resources/i18n/devhub_en.properties
@@ -244,9 +244,10 @@ pull-request.open.message = Hey! You can merge the pull request by clicking the 
 pull-request.merging = Merging...
 pull-request.merged = Merged
 pull-request.failed-to-merge = Failed to merge
-pull-request.failed-to-merge.message = We canâ€™t automatically merge this pull request due to merge conflicts. \
+pull-request.failed-to-merge.message = We can’t automatically merge this pull request due to merge conflicts. \
   Use the command line to resolve conflicts before continuing.
 pull-request.merged.message = It seems the branch is already merged into the master!
+pull-request.merged.message = The pull request is closed and merged into the master.
 pull-request.closed = Closed
 pull-request.closed.message = The pull request is closed and not merged into the master.
 

--- a/src/main/resources/i18n/devhub_en.properties
+++ b/src/main/resources/i18n/devhub_en.properties
@@ -244,7 +244,7 @@ pull-request.open.message = Hey! You can merge the pull request by clicking the 
 pull-request.merging = Merging...
 pull-request.merged = Merged
 pull-request.failed-to-merge = Failed to merge
-pull-request.failed-to-merge.message = We can’t automatically merge this pull request due to merge conflicts. \
+pull-request.failed-to-merge.message = We can\\''t automatically merge this pull request due to merge conflicts. \
   Use the command line to resolve conflicts before continuing.
 pull-request.merged.message = It seems the branch is already merged into the master!
 pull-request.merged.message = The pull request is closed and merged into the master.

--- a/src/main/resources/templates/project-pull.ftl
+++ b/src/main/resources/templates/project-pull.ftl
@@ -186,7 +186,7 @@ $(function() {
                 if(res.success) {
                     label.html('${i18n.translate("pull-request.merged")}');
                     btn.removeClass('btn-primary').addClass('btn-success');
-                    message.html('${i18n.translate("pull-request.closed.message")}');
+                    message.html('${i18n.translate("pull-request.merged.message")}');
                 }
                 else {
                     label.html('${i18n.translate("pull-request.failed-to-merge")}');

--- a/src/main/resources/templates/project-pull.ftl
+++ b/src/main/resources/templates/project-pull.ftl
@@ -191,7 +191,7 @@ $(function() {
                 else {
                     label.html('${i18n.translate("pull-request.failed-to-merge")}');
                     btn.removeClass('btn-primary').addClass('btn-danger');
-                    message.html('${i18n.translate("pull-request.failed-to-merge.message")}');
+                    message.html("${i18n.translate("pull-request.failed-to-merge.message")}");
                     $('.pull-request-badge').addClass('failed');
                 }
 


### PR DESCRIPTION
In this branch I fixed 3 issues regarding the pull request frontend:

1. In The message after a merge succeeded it said that the branch was not merged, while in fact it was.
2. In The message after a merge failed a single quote was not parsed correctly by the translator.
3. When going back after creating a pull-request, there was still a button "Create pull request", which gave a 404 error when clicked. This is fixed by adding no-store to the Cache-Control header.