### PR TITLE
Preview panel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<liquibase.slf4j.version>1.7.7</liquibase.slf4j.version>
 		<querydsl.version>3.6.0</querydsl.version>
 		<logback.version>1.0.13</logback.version>
-		<selenium.version>2.52.0</selenium.version>
+		<selenium.version>2.53.0</selenium.version>
 		<build.server.version>1.2.0</build.server.version>
 		<git.server.version>1.0.10</git.server.version>
 	</properties>

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/RootResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/RootResource.java
@@ -103,6 +103,21 @@ public class RootResource {
 
 	}
 
+	/**
+	 * formats a input string (for example for comments)
+	 * @param request
+	 * @param content the input string
+	 * @return the formatted sting, might be raw HTML
+	 */
+	@GET
+	@Path("/comment/preview")
+	@Produces(MediaType.TEXT_HTML)
+	public String getCommentPreview(@Context HttpServletRequest request,
+	                                @DefaultValue("Hello World!") @QueryParam("content") String content) {
+		// apply any processors for things like markdown and emojis here
+		return content;
+	}
+
     @GET
     @Path("version")
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/resources/i18n/devhub_en.properties
+++ b/src/main/resources/i18n/devhub_en.properties
@@ -234,6 +234,7 @@ button.label.review = Review
 button.label.previous-review = View previous review
 button.label.options = Options
 button.label.confirm = Confirm
+button.label.preview = Preview
 
 panel.label.add-comment = Add a comment
 panel.label.add-comment-emoji-link = Click here for a full list of supported emojies.

--- a/src/main/resources/static/less/devhub.less
+++ b/src/main/resources/static/less/devhub.less
@@ -896,3 +896,7 @@ img.emoji {
 		cursor: pointer;
 	}
 }
+
+#btn-preview {
+	float: right;
+}

--- a/src/main/resources/templates/project-diff-view.ftl
+++ b/src/main/resources/templates/project-diff-view.ftl
@@ -40,6 +40,7 @@
                     <textarea rows="5" class="form-control" name="content" style="margin-bottom:10px;"></textarea>
                     <button type="submit" class="btn btn-primary">${i18n.translate("button.label.submit")}</button>
                     <button type="button" class="btn btn-default" id="btn-cancel">${i18n.translate("button.label.cancel")}</button>
+                    <button type="button" class="btn btn-default" id="btn-preview">${i18n.translate("button.label.preview")}</button>
                 </form>
             </div>
         </div>
@@ -69,6 +70,28 @@
                 $('[name="content"]', '#pull-comment-form').val('');
             });
             event.preventDefault();
+        });
+    });
+    $(function () {
+        $('#btn-preview').click(function (event) {
+            $.get('/comment/preview', {
+                "content": $('textarea.form-control').val()
+            }).done(function (res) {
+                var previewPanel = $('#preview-panel');
+                if (previewPanel.length){
+                    previewPanel.find('.panel-body:first').empty();
+                    previewPanel.find('.panel-body').append(res);
+                } else {
+                    $('<hr style="border-color: #DDD;">'+
+                        '<div class="panel panel-default" id ="preview-panel">'+
+                        '<div class="panel-heading">Preview</div>'+
+                        '<div class="panel-body">'+
+                        res +
+                        '</div>' +
+                        '</div>').appendTo('.panel-comment-form .panel-body');
+                }
+                event.preventDefault();
+            });
         });
     });
 </script>

--- a/src/main/resources/templates/project-pull-diff-view.ftl
+++ b/src/main/resources/templates/project-pull-diff-view.ftl
@@ -102,7 +102,7 @@
 [/#if]
     </div>
 
-    <div class="panel panel-default" style="position: relative">
+    <div class="panel panel-default panel-comment-form" style="position: relative">
         <div class="panel-heading">
         ${i18n.translate("panel.label.add-comment")}
             <span> - </span>
@@ -115,6 +115,7 @@
                 <textarea rows="5" class="form-control" name="content" style="margin-bottom:10px;"></textarea>
                 <button type="submit" class="btn btn-primary">${i18n.translate("button.label.submit")}</button>
                 <button type="button" class="btn btn-default" id="btn-cancel">${i18n.translate("button.label.cancel")}</button>
+                <button type="button" class="btn btn-default" id="btn-preview">${i18n.translate("button.label.preview")}</button>
             </form>
         </div>
     </div>
@@ -140,6 +141,29 @@
                         $('[name="content"]', '#pull-comment-form').val('');
                     });
                 event.preventDefault();
+            });
+        });
+
+        $(function () {
+            $('#btn-preview').click(function (event) {
+                $.get('/comment/preview', {
+                    "content": $('textarea.form-control').val()
+                }).done(function (res) {
+                    var previewPanel = $('#preview-panel');
+                    if (previewPanel.length){
+                        previewPanel.find('.panel-body:first').empty();
+                        previewPanel.find('.panel-body').append(res);
+                    } else {
+                        $('<hr style="border-color: #DDD;">'+
+                                '<div class="panel panel-default" id ="preview-panel">'+
+                                '<div class="panel-heading">Preview</div>'+
+                                '<div class="panel-body">'+
+                                res +
+                                '</div>' +
+                                '</div>').appendTo('.panel-comment-form .panel-body');
+                    }
+                    event.preventDefault();
+                });
             });
         });
     </script>

--- a/src/main/resources/templates/project-pull.ftl
+++ b/src/main/resources/templates/project-pull.ftl
@@ -119,6 +119,7 @@
             <form class="form-horizontal" id="pull-comment-form" >
                 <textarea rows="5" class="form-control" name="content" style="margin-bottom:10px;"></textarea>
                 <button type="submit" class="btn btn-primary">${i18n.translate("button.label.submit")}</button>
+                <button type="button" class="btn btn-default" id="btn-preview">${i18n.translate("button.label.preview")}</button>
             </form>
         </div>
     </div>
@@ -181,6 +182,28 @@
                 $('[name="content"]', '#pull-comment-form').val('');
             });
             event.preventDefault();
+        });
+    });
+    $(function () {
+        $('#btn-preview').click(function (event) {
+            $.get('/comment/preview', {
+                "content": $('textarea.form-control').val()
+            }).done(function (res) {
+                var previewPanel = $('#preview-panel');
+                if (previewPanel.length){
+                    previewPanel.find('.panel-body:first').empty();
+                    previewPanel.find('.panel-body').append(res);
+                } else {
+                    $('<hr style="border-color: #DDD;">'+
+                            '<div class="panel panel-default" id ="preview-panel">'+
+                            '<div class="panel-heading">Preview</div>'+
+                            '<div class="panel-body">'+
+                            res +
+                            '</div>' +
+                            '</div>').appendTo('.panel-comment-form .panel-body');
+                }
+                event.preventDefault();
+            });
         });
     });
 </script>

--- a/src/test/java/nl/tudelft/ewi/devhub/webtests/ProjectTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/webtests/ProjectTest.java
@@ -10,12 +10,11 @@ import nl.tudelft.ewi.devhub.webtests.views.CommitsView;
 import nl.tudelft.ewi.devhub.webtests.views.CommitsView.Commit;
 import nl.tudelft.ewi.devhub.webtests.views.ContributorsView;
 import nl.tudelft.ewi.devhub.webtests.views.ContributorsView.Contributor;
-import nl.tudelft.ewi.devhub.webtests.views.DiffInCommitView;
 import nl.tudelft.ewi.devhub.webtests.views.DiffElement;
+import nl.tudelft.ewi.devhub.webtests.views.DiffInCommitView;
 import nl.tudelft.ewi.git.models.CommitModel;
 import nl.tudelft.ewi.git.models.DetailedCommitModel;
 import nl.tudelft.ewi.git.models.DiffBlameModel;
-
 import nl.tudelft.ewi.git.web.api.BranchApi;
 import nl.tudelft.ewi.git.web.api.CommitApi;
 import nl.tudelft.ewi.git.web.api.RepositoriesApi;
@@ -25,12 +24,11 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import javax.inject.Inject;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import javax.inject.Inject;
+
+import static org.junit.Assert.*;
 
 public class ProjectTest extends WebTest {
 
@@ -199,4 +197,33 @@ public class ProjectTest extends WebTest {
 		}
 	}
 
+	@Test
+	public void testEmptyCommentPreview() {
+		DiffInCommitView view = openLoginScreen()
+				.login(NET_ID, PASSWORD)
+				.toCoursesView()
+				.listMyProjects()
+				.get(0).click()
+				.listCommits()
+				.get(0).click();
+
+		view.setCommentInput("");
+		view.renderPreview();
+		assertEquals("" ,view.getPreviewPanelContent());
+	}
+
+	@Test
+	public void testSmallCommentPreview() {
+		DiffInCommitView view = openLoginScreen()
+				.login(NET_ID, PASSWORD)
+				.toCoursesView()
+				.listMyProjects()
+				.get(0).click()
+				.listCommits()
+				.get(0).click();
+
+		view.setCommentInput("Hello World!");
+		view.renderPreview();
+		assertEquals("Hello World!", view.getPreviewPanelContent());
+	}
 }

--- a/src/test/java/nl/tudelft/ewi/devhub/webtests/views/DiffInCommitView.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/webtests/views/DiffInCommitView.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -74,5 +75,30 @@ public class DiffInCommitView extends ProjectInCommitView {
 		invariant(); // Should still be on the same page
 		return new DiffInCommitView(getDriver());
 	}
-	
+
+	public DiffInCommitView renderPreview() {
+		final WebElement previewButton = getDriver().findElement(By.id("btn-preview"));
+		previewButton.click();
+
+		return new DiffInCommitView(getDriver());
+	}
+
+	public String getPreviewPanelContent() {
+		final WebElement previewPanel =  getDriver().findElement(By.cssSelector("#preview-panel .panel-body"));
+		if (previewPanel.getText().isEmpty()) {
+			// in case the preview is filed with HTML instead of text
+			final List<WebElement> panelBodyElements = previewPanel.findElements(By.xpath(".//*"));
+			return String.join(" ", panelBodyElements
+					.stream()
+					.map(webElement -> webElement.getAttribute("innerHTML"))
+					.collect(Collectors.toList()));
+		} else {
+			return previewPanel.getText();
+		}
+	}
+
+	public void setCommentInput(String text) {
+		final WebElement textarea = getDriver().findElement(By.cssSelector("#pull-comment-form textarea"));
+		textarea.sendKeys(text);
+	}
 }


### PR DESCRIPTION
This PR replaces #393, and merges into `MarkDownRendering` instead of `master`. Without Markdown comments are pretty much WYSIWYG, which makes a preview window pretty much useless. But on top of the Markdown feature, it is very nice to have. Please rebase this PR on the `MarkDownRendering` branch, fix the conflicts. While there aren't any merge conflicts, the implementation of preview window does currently not support the changes in the markdown branch, which needs to be resolved.