### PR TITLE
Using chrome instead of firefox for webdriver.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,18 @@
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-chrome-driver</artifactId>
+			<version>${selenium.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>httpclient</artifactId>
+					<groupId>org.apache.httpcomponents</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-support</artifactId>
 			<version>${selenium.version}</version>
 			<scope>test</scope>

--- a/src/test/java/nl/tudelft/ewi/devhub/webtests/rules/DriverResource.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/webtests/rules/DriverResource.java
@@ -2,7 +2,7 @@ package nl.tudelft.ewi.devhub.webtests.rules;
 
 import org.junit.rules.ExternalResource;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -19,7 +19,7 @@ public class DriverResource extends ExternalResource {
 
 	@Override
 	protected void before() throws Throwable {
-		WebDriver driver = new FirefoxDriver();
+		WebDriver driver = new ChromeDriver();
 		driver.manage().window().maximize();
 		driverRef.set(driver);
 	}


### PR DESCRIPTION
Firefox 47 does not play well with webdriver 2.53:
http://stackoverflow.com/questions/37693106/selenium-2-53-not-working-on-firefox-47

Switched to chrome instead of downgrading my firefox to 46. (you may have to (brew) install `chromedriver`)

For me two tests fail at the moment, both related to setting the state in the DeliveryReviewView.

> AssignmentReviewTest.testReviewForm:64 » NoSuchElement No value present
> AssignmentReviewTest.testSubmitReview:79 » NoSuchElement No value present

