### PR TITLE
setting status through select ignores whitespace

### DIFF
--- a/src/test/java/nl/tudelft/ewi/devhub/webtests/views/DeliveryReviewView.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/webtests/views/DeliveryReviewView.java
@@ -125,8 +125,9 @@ public class DeliveryReviewView extends ProjectSidebarView {
         public State getSelectedState() {
             final WebElement element = getDriver().findElement(STATE_SELECTOR);
             Select select = new Select(element);
+            String selected = select.getFirstSelectedOption().getText().replaceAll("\\s+", "");
 
-            return State.valueOf(select.getFirstSelectedOption().getText().toUpperCase());
+            return State.valueOf(selected.toUpperCase());
         }
 
         @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/src/test/java/nl/tudelft/ewi/devhub/webtests/views/DeliveryReviewView.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/webtests/views/DeliveryReviewView.java
@@ -3,7 +3,6 @@ package nl.tudelft.ewi.devhub.webtests.views;
 import lombok.Data;
 import nl.tudelft.ewi.devhub.server.database.entities.Delivery;
 import nl.tudelft.ewi.devhub.server.database.entities.Delivery.State;
-import org.apache.commons.lang.WordUtils;
 import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -138,7 +137,10 @@ public class DeliveryReviewView extends ProjectSidebarView {
 
             select.getOptions()
                 .stream()
-                .filter(webElement -> WordUtils.capitalize(state.toString().toLowerCase()).equals(webElement.getText()))
+                .filter(webElement -> 
+                    webElement.getText()
+                	    .replaceAll("\\s+", "")
+                	    .equalsIgnoreCase(state.toString()))
                 .findAny().get().click();
         }
 


### PR DESCRIPTION
In Chrome, tests failed because the setting a status included a comparison to the status getText(), which
included white space.

New test implementation ignores the whitespace, and now should work in both firefox and chrome.