### PR TITLE
Migration to query dsl 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<h2.version>1.3.173</h2.version>
 		<liquibase.version>3.3.1</liquibase.version>
 		<liquibase.slf4j.version>1.7.7</liquibase.slf4j.version>
-		<querydsl.version>3.6.0</querydsl.version>
+		<querydsl.version>4.1.4</querydsl.version>
 		<logback.version>1.0.13</logback.version>
 		<selenium.version>2.53.0</selenium.version>
 		<build.server.version>1.2.0</build.server.version>
@@ -248,13 +248,8 @@
 			<version>1.2.1</version>
 		</dependency>
 		<dependency>
-			<groupId>com.mysema.querydsl</groupId>
+			<groupId>com.querydsl</groupId>
 			<artifactId>querydsl-jpa</artifactId>
-			<version>${querydsl.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.mysema.querydsl</groupId>
-			<artifactId>querydsl-apt</artifactId>
 			<version>${querydsl.version}</version>
 		</dependency>
 		<dependency>
@@ -487,8 +482,8 @@
 			</plugin>
 			<plugin>
 				<groupId>com.mysema.maven</groupId>
-				<artifactId>maven-apt-plugin</artifactId>
-				<version>1.0.4</version>
+				<artifactId>apt-maven-plugin</artifactId>
+				<version>1.1.3</version>
 				<executions>
 					<execution>
 						<goals>
@@ -496,10 +491,17 @@
 						</goals>
 						<configuration>
 							<outputDirectory>target/metamodel</outputDirectory>
-							<processor>com.mysema.query.apt.jpa.JPAAnnotationProcessor</processor>
+							<processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
 						</configuration>
 					</execution>
 				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>com.querydsl</groupId>
+						<artifactId>querydsl-apt</artifactId>
+						<version>${querydsl.version}</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Assignments.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Assignments.java
@@ -19,18 +19,18 @@ public class Assignments extends Controller<Assignment> {
     }
 
     public Assignment find(CourseEdition course, Long assignmentId) {
-        return ensureNotNull(query().from(QAssignment.assignment)
+        return ensureNotNull(query().selectFrom(QAssignment.assignment)
             .where(QAssignment.assignment.courseEdition.eq(course)
             .and(QAssignment.assignment.assignmentId.eq(assignmentId)))
-            .singleResult(QAssignment.assignment),
+            .fetchOne(),
             "Could not find assignment " + assignmentId + " for " + course.getCode());
     }
 
     public boolean exists(CourseEdition course, Long assignmentId) {
-        return query().from(QAssignment.assignment)
+        return query().selectFrom(QAssignment.assignment)
             .where(QAssignment.assignment.courseEdition.eq(course)
             .and(QAssignment.assignment.assignmentId.eq(assignmentId)))
-            .exists();
+            .fetchCount() > 0;
     }
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/BuildResults.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/BuildResults.java
@@ -14,6 +14,8 @@ import javax.persistence.EntityNotFoundException;
 import java.util.Collection;
 import java.util.Map;
 
+
+import static com.querydsl.core.group.GroupBy.groupBy;
 import static nl.tudelft.ewi.devhub.server.database.entities.QBuildResult.buildResult;
 
 public class BuildResults extends Controller<BuildResult> {
@@ -33,10 +35,10 @@ public class BuildResults extends Controller<BuildResult> {
 		Preconditions.checkNotNull(repository);
 		Preconditions.checkNotNull(commitId);
 		
-		BuildResult result = query().from(buildResult)
+		BuildResult result = query().selectFrom(buildResult)
 				.where(buildResult.commit.repository.id.eq(repository.getId()))
 				.where(buildResult.commit.commitId.equalsIgnoreCase(commitId))
-				.singleResult(buildResult);
+				.fetchOne();
 
 		if (result == null) {
 			throw new EntityNotFoundException();
@@ -53,10 +55,10 @@ public class BuildResults extends Controller<BuildResult> {
 			return ImmutableMap.of();
 		}
 
-		return query().from(buildResult)
+		return query().selectFrom(buildResult)
 				.where(buildResult.commit.repository.eq(repository)
 						.and(buildResult.commit.commitId.in(commitIds)))
-				.map(buildResult.commit.commitId, buildResult);
+				.transform(groupBy(buildResult.commit.commitId).as(buildResult));
 	}
 
 	@Transactional

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/BuildServers.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/BuildServers.java
@@ -21,16 +21,16 @@ public class BuildServers extends Controller<BuildServer> {
 
 	@Transactional
 	public List<BuildServer> listAll() {
-		return ImmutableList.copyOf(query().from(QBuildServer.buildServer)
+		return ImmutableList.copyOf(query().selectFrom(QBuildServer.buildServer)
 				.orderBy(QBuildServer.buildServer.name.toLowerCase().asc())
-				.list(QBuildServer.buildServer));
+				.fetch());
 	}
 
 	@Transactional
 	public BuildServer findById(long id) {
-		BuildServer buildServer = query().from(QBuildServer.buildServer)
+		BuildServer buildServer = query().selectFrom(QBuildServer.buildServer)
 				.where(QBuildServer.buildServer.id.eq(id))
-				.singleResult(QBuildServer.buildServer);
+				.fetchOne();
 		
 		if (buildServer == null) {
 			throw new EntityNotFoundException();
@@ -43,10 +43,10 @@ public class BuildServers extends Controller<BuildServer> {
 		Preconditions.checkNotNull(name);
 		Preconditions.checkNotNull(secret);
 		
-		BuildServer buildServer = query().from(QBuildServer.buildServer)
+		BuildServer buildServer = query().selectFrom(QBuildServer.buildServer)
 				.where(QBuildServer.buildServer.name.equalsIgnoreCase(name))
 				.where(QBuildServer.buildServer.secret.eq(secret))
-				.singleResult(QBuildServer.buildServer);
+				.fetchOne();
 		
 		if (buildServer == null) {
 			throw new EntityNotFoundException();

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Commits.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Commits.java
@@ -96,10 +96,10 @@ public class Commits extends Controller<Commit> {
 	 */
 	@Transactional
 	public boolean exists(RepositoryEntity repository, String commitId) {
-		return query().from(commit)
+		return query().selectFrom(commit)
 			.where(commit.repository.eq(repository))
 			.where(commit.commitId.eq(commitId))
-			.exists();
+			.fetchCount() > 0;
 	}
 
 	/**
@@ -110,10 +110,10 @@ public class Commits extends Controller<Commit> {
      */
 	@Transactional
 	public Stream<Commit> getMostRecentCommits(List<? extends RepositoryEntity> repositoryEntities, long limit) {
-		return toStream(query().from(commit)
+		return toStream(query().selectFrom(commit)
 			.where(commit.repository.in(repositoryEntities))
 			.orderBy(commit.pushTime.desc())
 			.limit(limit)
-			.iterate(commit));
+			.iterate());
 	}
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Controller.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Controller.java
@@ -1,11 +1,11 @@
 package nl.tudelft.ewi.devhub.server.database.controllers;
 
 import com.mysema.commons.lang.CloseableIterator;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.extern.slf4j.Slf4j;
 
 import com.google.common.base.Preconditions;
 import com.google.inject.persist.Transactional;
-import com.mysema.query.jpa.impl.JPAQuery;
 
 import org.hibernate.Hibernate;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -57,8 +57,8 @@ public class Controller<T> {
 		return entity;
 	}
 
-	public JPAQuery query() {
-		return new JPAQuery(entityManager);
+	public JPAQueryFactory query() {
+		return new JPAQueryFactory(entityManager);
 	}
 
 	protected T ensureNotNull(T entry, String error) {

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Courses.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Courses.java
@@ -25,9 +25,9 @@ public class Courses extends Controller<Course> {
 	@Transactional
 	public Course find(String courseCode) {
 		Preconditions.checkNotNull(courseCode);
-		return ensureNotNull(query().from(course)
-			.where(course.course.code.equalsIgnoreCase(courseCode))
-			.singleResult(course), "Could not find course with code: " + courseCode);
+		return ensureNotNull(query().selectFrom(course)
+			.where(course.code.equalsIgnoreCase(courseCode))
+			.fetchOne(), "Could not find course with code: " + courseCode);
 	}
 
 	@Transactional

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Groups.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Groups.java
@@ -25,9 +25,9 @@ public class Groups extends Controller<Group> {
 	@Transactional
 	public Group findByRepoName(String repoName) {
 		Preconditions.checkNotNull(repoName);
-		Group res = query().from(group)
+		Group res = query().selectFrom(group)
 			.where(group.repository.repositoryName.equalsIgnoreCase(repoName))
-			.singleResult(group);
+			.fetchOne();
 
 		return ensureNotNull(res, "Could not find group by repository name: " + repoName);
 	}
@@ -35,28 +35,28 @@ public class Groups extends Controller<Group> {
 	@Transactional
 	public List<Group> find(CourseEdition course) {
 		Preconditions.checkNotNull(course);
-		return query().from(group)
+		return query().selectFrom(group)
 			.where(group.courseEdition.id.eq(course.getId()))
 			.orderBy(group.groupNumber.asc())
-			.list(group);
+			.fetch();
 	}
 
 	@Transactional
 	public List<Group> listFor(User user) {
 		Preconditions.checkNotNull(user);
-		return query().from(group)
+		return query().selectFrom(group)
 			.where(group.members.contains(user))
 			.orderBy(group.groupNumber.asc())
-			.list(group);
+			.fetch();
 	}
 
 	@Transactional
 	public Group find(CourseEdition course, long groupNumber) {
 		Preconditions.checkNotNull(course);
-		Group res = query().from(group)
+		Group res = query().selectFrom(group)
 			.where(group.courseEdition.id.eq(course.getId()))
 			.where(group.groupNumber.eq(groupNumber))
-			.singleResult(group);
+			.fetchOne();
 
 		return ensureNotNull(res, "Could not find group by course: " + course + " and groupNumber: " + groupNumber);
 	}
@@ -66,10 +66,10 @@ public class Groups extends Controller<Group> {
 		Preconditions.checkNotNull(courseEdition);
 		Preconditions.checkNotNull(user);
 
-		return ensureNotNull(query().from(group)
+		return ensureNotNull(query().selectFrom(group)
 			.where(group.members.contains(user)
 			.and(group.courseEdition.eq(courseEdition)))
-			.singleResult(group),
+			.fetchOne(),
 			String.format("Could not find group by course %s and user %s", courseEdition, user));
 	}
 

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Issues.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Issues.java
@@ -22,37 +22,37 @@ public class Issues extends Controller<Issue> {
 	
 	@Transactional
 	public List<Issue> findAssignedIssues(final RepositoryEntity repo, User user){
-		return query().from(issue)
+		return query().selectFrom(issue)
 			.where(issue.repository.eq(repo).and(issue.assignee.eq(user)))
-			.list(issue);
+			.fetch();
 	}
 	
 	@Transactional
 	public List<Issue> findOpenIssues(final RepositoryEntity repo){
-		return query().from(issue)
+		return query().selectFrom(issue)
 			.where(issue.repository.eq(repo).and(issue.open.isTrue()))
-			.list(issue);
+			.fetch();
 	}
 	
 	@Transactional
 	public List<Issue> findClosedIssues(final RepositoryEntity repo){
-		return query().from(issue)
+		return query().selectFrom(issue)
 			.where(issue.repository.eq(repo).and(issue.open.isFalse()))
-			.list(issue);
+			.fetch();
 	}
 
 	@Transactional
 	public List<Issue> findUnassignedIssues(final RepositoryEntity repo){
-		return query().from(issue)
+		return query().selectFrom(issue)
 			.where(issue.repository.eq(repo).and(issue.assignee.isNull()))
-			.list(issue);
+			.fetch();
 	}
 
 	@Transactional
 	public List<Issue> findIssueById(final RepositoryEntity repo, final long id){
-		return query().from(issue)
+		return query().selectFrom(issue)
 			.where(issue.repository.eq(repo).and(issue.issueId.eq(id)))
-			.list(issue);
+			.fetch();
 	}
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/PrivateRepositories.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/PrivateRepositories.java
@@ -27,20 +27,20 @@ public class PrivateRepositories extends Controller<PrivateRepository> {
 		Preconditions.checkNotNull(username);
 		Preconditions.checkNotNull(repositoryTitle);
 
-		return ensureNotNull(query().from(privateRepository)
+		return ensureNotNull(query().selectFrom(privateRepository)
 				.where(privateRepository.owner.netId.equalsIgnoreCase(username)
 					.and(privateRepository.title.equalsIgnoreCase(repositoryTitle)))
-				.singleResult(privateRepository),
+				.fetchOne(),
 			"Could not find repository " + username + "/" + repositoryTitle);
 	}
 
 	@Transactional
 	public List<PrivateRepository> findPrivateRepositories(User user) {
 		Preconditions.checkNotNull(user);
-		return query().from(privateRepository)
+		return query().selectFrom(privateRepository)
 			.where(privateRepository.owner.eq(user)
 			.or(privateRepository.collaborators.contains(user)))
-			.list(privateRepository);
+			.fetch();
 	}
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/PullRequestComments.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/PullRequestComments.java
@@ -30,11 +30,11 @@ public class PullRequestComments extends Controller<PullRequestComment> {
      */
     @Transactional
     public Stream<PullRequestComment> getMostRecentPullRequestComments(List<? extends RepositoryEntity> repositoryEntities, long limit) {
-        return toStream(query().from(pullRequestComment)
+        return toStream(query().selectFrom(pullRequestComment)
             .where(pullRequestComment.pullRequest.repository.in(repositoryEntities))
             .orderBy(pullRequestComment.timestamp.desc())
             .limit(limit)
-            .iterate(pullRequestComment));
+            .iterate());
     }
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/PullRequests.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/PullRequests.java
@@ -31,10 +31,10 @@ public class PullRequests extends Controller<PullRequest> {
 	 */
 	@Transactional
 	public PullRequest findById(final RepositoryEntity repositoryEntity, final long id) {
-		return ensureNotNull(query().from(pullRequest)
+		return ensureNotNull(query().selectFrom(pullRequest)
 				.where(pullRequest.issueId.eq(id)
 						.and(pullRequest.repository.eq(repositoryEntity)))
-				.singleResult(pullRequest), "No pull request exists for id " + id);
+				.fetchOne(), "No pull request exists for id " + id);
 	}
 
 	/**
@@ -45,11 +45,11 @@ public class PullRequests extends Controller<PullRequest> {
 	 */
 	@Transactional
 	public Optional<PullRequest> findOpenPullRequest(final RepositoryEntity repositoryEntity, final String branchName) {
-		return Optional.ofNullable(query().from(pullRequest)
+		return Optional.ofNullable(query().selectFrom(pullRequest)
 			.where(pullRequest.repository.eq(repositoryEntity))
 			.where(pullRequest.branchName.eq(branchName))
 			.where(pullRequest.open.isTrue())
-			.singleResult(pullRequest));
+			.fetchOne());
 	}
 
 	/**
@@ -59,11 +59,11 @@ public class PullRequests extends Controller<PullRequest> {
 	 */
 	@Transactional
 	public List<PullRequest> findOpenPullRequests(final RepositoryEntity repositoryEntity) {
-		return query().from(pullRequest)
+		return query().selectFrom(pullRequest)
 			.where(pullRequest.repository.eq(repositoryEntity))
 			.where(pullRequest.open.isTrue())
 			.orderBy(pullRequest.issueId.desc())
-			.list(pullRequest);
+			.fetch();
 	}
 
 	/**
@@ -73,11 +73,11 @@ public class PullRequests extends Controller<PullRequest> {
 	 */
 	@Transactional
 	public List<PullRequest> findClosedPullRequests(final RepositoryEntity repositoryEntity) {
-		return query().from(pullRequest)
+		return query().selectFrom(pullRequest)
 			.where(pullRequest.repository.eq(repositoryEntity))
 			.where(pullRequest.open.isFalse())
 			.orderBy(pullRequest.issueId.desc())
-			.list(pullRequest);
+			.fetch();
 	}
 
 	/**
@@ -88,11 +88,11 @@ public class PullRequests extends Controller<PullRequest> {
 	 */
 	@Transactional
 	public boolean openPullRequestExists(final RepositoryEntity repositoryEntity, final String branchName) {
-		return query().from(pullRequest)
+		return query().selectFrom(pullRequest)
 			.where(pullRequest.repository.eq(repositoryEntity))
 			.where(pullRequest.branchName.eq(branchName))
 			.where(pullRequest.open.isTrue())
-			.exists();
+			.fetchCount() > 0;
 	}
 
 	/**
@@ -103,11 +103,11 @@ public class PullRequests extends Controller<PullRequest> {
      */
 	@Transactional
 	public Stream<PullRequest> findLastPullRequests(final List<? extends RepositoryEntity> repositoryEntities, long limit) {
-		return toStream(query().from(pullRequest)
+		return toStream(query().selectFrom(pullRequest)
 			.where(pullRequest.repository.in(repositoryEntities))
 			.orderBy(pullRequest.timestamp.desc())
 			.limit(limit)
-			.iterate(pullRequest));
+			.iterate());
 	}
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/RepositoriesController.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/RepositoriesController.java
@@ -21,9 +21,9 @@ public class RepositoriesController extends Controller<RepositoryEntity> {
 
 	@Transactional
 	public RepositoryEntity find(final String repositoryName) {
-		return ensureNotNull(query().from(repositoryEntity)
+		return ensureNotNull(query().selectFrom(repositoryEntity)
 			.where(repositoryEntity.repositoryName.equalsIgnoreCase(repositoryName))
-			.singleResult(repositoryEntity), String.format("No repository found for %s", repositoryName));
+			.fetchOne(), String.format("No repository found for %s", repositoryName));
 	}
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Users.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Users.java
@@ -14,6 +14,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+
 public class Users extends Controller<User> {
 
 	@Inject
@@ -23,9 +26,9 @@ public class Users extends Controller<User> {
 
 	@Transactional
 	public User find(long id) {
-		User user = query().from(QUser.user)
+		User user = query().selectFrom(QUser.user)
 			.where(QUser.user.id.eq(id))
-			.singleResult(QUser.user);
+			.fetchOne();
 
 		return ensureNotNull(user, "Could not find user with id: " + id);
 	}
@@ -34,9 +37,9 @@ public class Users extends Controller<User> {
 	public User findByNetId(String netId) {
 		Preconditions.checkNotNull(netId);
 		
-		User user = query().from(QUser.user)
+		User user = query().selectFrom(QUser.user)
 			.where(QUser.user.netId.equalsIgnoreCase(netId))
-			.singleResult(QUser.user);
+			.fetchOne();
 
 		return ensureNotNull(user, "Could not find user with netID:" + netId);
 	}
@@ -45,17 +48,17 @@ public class Users extends Controller<User> {
 	public List<User> listAllWithNetIdPrefix(String prefix) {
 		Preconditions.checkNotNull(prefix);
 		
-		return query().from(QUser.user)
+		return query().selectFrom(QUser.user)
 			.where(QUser.user.netId.startsWithIgnoreCase(prefix))
 			.orderBy(QUser.user.netId.toLowerCase().asc())
-			.list(QUser.user);
+			.fetch();
 	}
 
 	@Transactional
 	public List<User> listAdministrators() {
-		return query().from(QUser.user)
+		return query().selectFrom(QUser.user)
 			.where(QUser.user.admin.isTrue())
-			.list(QUser.user);
+			.fetch();
 	}
 
 	@Transactional
@@ -70,10 +73,10 @@ public class Users extends Controller<User> {
 				.map(String::toLowerCase)
 				.collect(Collectors.toList());
 
-		return query().from(QUser.user)
+		return query().selectFrom(QUser.user)
 			.where(QUser.user.netId.toLowerCase().in(lowerCasedNetIds))
 			.orderBy(QUser.user.netId.toLowerCase().asc())
-			.map(QUser.user.netId, QUser.user);
+			.transform(groupBy(QUser.user.netId).as(QUser.user));
 	}
 
 }


### PR DESCRIPTION
Querydsl moved to a new domain and has a new version out. 

The main issue is that 
.exists(); is gone in the newer version
The closest I could translate this is:
.fetchCount() > 0;

I opted for the fail fast FetchOne instead of FetchFirst, but this is debatable.

Further more map is no longer supported since they didn't like the usage of it and has become a group by.