### PR TITLE
WIP Automatically fill in build rubric, fixes #277

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/backend/ConsecutiveBuildFailureBackend.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/backend/ConsecutiveBuildFailureBackend.java
@@ -1,0 +1,118 @@
+package nl.tudelft.ewi.devhub.server.backend;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import nl.tudelft.ewi.devhub.server.database.controllers.Commits;
+import nl.tudelft.ewi.devhub.server.database.controllers.Deliveries;
+import nl.tudelft.ewi.devhub.server.database.entities.Assignment;
+import nl.tudelft.ewi.devhub.server.database.entities.Commit;
+import nl.tudelft.ewi.devhub.server.database.entities.Delivery;
+import nl.tudelft.ewi.devhub.server.database.entities.Group;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Checks whether between the previous assignments delivery and the current deliver, or the start of time if it's the first assignment
+ * any commits through any branches that are reachable from the commit that has been handed in contained 4 or more consecutive build failures.
+ */
+public class ConsecutiveBuildFailureBackend {
+    public static final int MAX_CONSECUTIVE_BUILD_FAILURES = 4;
+    private Commits commits;
+    private Deliveries deliveries;
+
+    @Inject
+    public ConsecutiveBuildFailureBackend(Commits commits, Deliveries deliveries) {
+        this.commits = commits;
+        this.deliveries = deliveries;
+    }
+
+    public boolean hasConsecutiveBuildFailures(Group group, Delivery delivery) {
+        final List<List<Commit>> commitsToCheck = commitsToCheckForBuildFailures(group, delivery);
+        return consecutiveBuildFailures(commitsToCheck);
+    }
+
+    protected static boolean consecutiveBuildFailures(List<List<Commit>> commitsToCheck) {
+        return commitsToCheck.stream().anyMatch(ConsecutiveBuildFailureBackend::hasFourFailingCommits);
+    }
+
+
+    protected static boolean hasFourFailingCommits(List<Commit> commits) {
+        int consecutive = 0;
+
+        for (Commit commit : commits) {
+            if (commit.getBuildResult().hasFailed()) {
+                consecutive++;
+                if (consecutive == MAX_CONSECUTIVE_BUILD_FAILURES) {
+                    return true;
+                }
+            } else {
+                consecutive = 0;
+            }
+        }
+
+        return false;
+    }
+
+    protected Optional<Commit> findRootCommit(Group group, Delivery delivery) {
+        final List<Assignment> assignments = group.getCourseEdition().getAssignments().stream()
+                .sorted(Assignment::compareTo)
+                .collect(toList());
+
+        final int index = assignments.indexOf(delivery.getAssignment());
+        final boolean firstAssignment = index < 1;
+
+        if (firstAssignment) {
+            return commits.firstCommitInRepo(group.getRepository());
+        } else {
+            final Assignment previousAssignment = assignments.get(index - 1);
+            return deliveries.getLastDelivery(previousAssignment, group).map(Delivery::getCommit);
+        }
+    }
+
+    protected List<List<Commit>> commitsToCheckForBuildFailures(Group group, Delivery delivery) {
+        final Commit deliveryCommit = delivery.getCommit();
+        Optional<List<List<Commit>>> commits = findRootCommit(group, delivery).map(prevCommit -> commitsTillRoot(deliveryCommit, prevCommit));
+
+        return commits.orElse(Lists.newArrayList());
+    }
+
+    protected static List<List<Commit>> commitsTillRoot(Commit commit, Commit root) {
+        List<List<Commit>> commits = Lists.newArrayList();
+        commitsBetween(commit, root, commits, new ArrayList<>());
+
+        return commits;
+    }
+
+    private static void commitsBetween(Commit current, Commit root, List<List<Commit>> allCommitPaths, List<Commit> currentCommits) {
+        currentCommits.add(current);
+
+        if (isPastEnd(current, root)) {
+            allCommitPaths.add(currentCommits);
+        } else {
+            List<Commit> parents = current.getParents();
+            if (parents.size() == 1) {
+                commitsBetween(parents.get(0), root, allCommitPaths, currentCommits);
+            } else {
+                for (Commit commit : parents) {
+                    List<Commit> currentCopy = Lists.newArrayList(currentCommits);
+                    commitsBetween(commit, root, allCommitPaths, currentCopy);
+                }
+            }
+        }
+    }
+
+    /**
+     * We are at the end of commits to consider for consecutive build failures if we either rejoined the last commit or are past it in time.
+     *
+     * @param end    the commit of the last delivery for the previous assignment.
+     * @param commit the commit we are considering right now.
+     * @return true if the current commit shouldn't be considered anymore.
+     */
+    private static boolean isPastEnd(Commit end, Commit commit) {
+        return commit.getCommitTime().before(end.getCommitTime()) || commit.equals(end);
+    }
+}

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Commits.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Commits.java
@@ -36,6 +36,13 @@ public class Commits extends Controller<Commit> {
 		return Optional.ofNullable(entityManager.find(Commit.class, key));
 	}
 
+	public Optional<Commit> firstCommitInRepo(RepositoryEntity repositoryEntity) {
+	 return Optional.ofNullable(query().from(commit)
+				.where(commit.repository.eq(repositoryEntity))
+				.orderBy(commit.commitTime.asc())
+				.singleResult(commit));
+	}
+
 	/**
 	 * Ensure that a commit exists in the database. Recursively check if the parents exists as well.
 	 *

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Deliveries.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/controllers/Deliveries.java
@@ -1,11 +1,13 @@
 package nl.tudelft.ewi.devhub.server.database.controllers;
 
 import nl.tudelft.ewi.devhub.server.database.entities.Assignment;
+import nl.tudelft.ewi.devhub.server.database.entities.Commit;
 import nl.tudelft.ewi.devhub.server.database.entities.Delivery;
 import nl.tudelft.ewi.devhub.server.database.entities.Group;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
+import nl.tudelft.ewi.devhub.server.database.entities.rubrics.Mastery;
 
 import javax.persistence.EntityManager;
 import java.util.Comparator;
@@ -109,6 +111,15 @@ public class Deliveries extends Controller<Delivery> {
 					.and(delivery.group.eq(group)))
 				.singleResult(delivery),
             "No delivery found for id " + deliveryId);
+    }
+
+
+    public Optional<Delivery> deliveryForCommit(Commit commit) {
+        return Optional.ofNullable(
+                query().from(delivery)
+                    .where(delivery.commit.eq(commit))
+                    .singleResult(delivery)
+        );
     }
 
     /**

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Assignment.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Assignment.java
@@ -8,9 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import nl.tudelft.ewi.devhub.server.database.Base;
 import nl.tudelft.ewi.devhub.server.database.entities.identity.FKSegmentedIdentifierGenerator;
-import nl.tudelft.ewi.devhub.server.database.entities.rubrics.DutchGradingStrategy;
-import nl.tudelft.ewi.devhub.server.database.entities.rubrics.GradingStrategy;
-import nl.tudelft.ewi.devhub.server.database.entities.rubrics.Task;
+import nl.tudelft.ewi.devhub.server.database.entities.rubrics.*;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -43,6 +41,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Created by jgmeligmeyling on 04/03/15.
@@ -123,6 +122,7 @@ public class Assignment implements Comparable<Assignment>, Base {
 			.mapToDouble(Task::getMaximalNumberOfPoints)
 			.sum();
 	}
+
 
 	@JsonIgnore
 	public GradingStrategy getGradingStrategy() {

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/ConsecutiveBuildFailureBackendTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/ConsecutiveBuildFailureBackendTest.java
@@ -1,0 +1,172 @@
+package nl.tudelft.ewi.devhub.server.backend;
+
+import com.google.common.collect.Lists;
+import lombok.AllArgsConstructor;
+import nl.tudelft.ewi.devhub.server.database.controllers.Commits;
+import nl.tudelft.ewi.devhub.server.database.controllers.Deliveries;
+import nl.tudelft.ewi.devhub.server.database.entities.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(Enclosed.class)
+public class ConsecutiveBuildFailureBackendTest {
+
+    @RunWith(MockitoJUnitRunner.class)
+    public static class RootCommitTests {
+        private ConsecutiveBuildFailureBackend commitChecking;
+        private Date now = new Date();
+
+        @Mock
+        private Deliveries deliveries;
+        @Mock
+        private Commits commits;
+        @Mock
+        private Group group;
+        @Mock
+        private CourseEdition courseEdition;
+        @Mock
+        private Commit firstCommit;
+        @Mock
+        private Delivery delivery;
+
+
+        @Before
+        public void setUp() {
+            commitChecking = new ConsecutiveBuildFailureBackend(commits, deliveries);
+            when(group.getCourseEdition()).thenReturn(courseEdition);
+            when(commits.firstCommitInRepo(any())).thenReturn(Optional.of(firstCommit));
+        }
+
+        @Test
+        public void testFindRootCommitNoPreviousDelivery() {
+            Optional<Commit> rootCommit = commitChecking.findRootCommit(group, delivery);
+            assertEquals(firstCommit, rootCommit.get());
+        }
+
+        @Test
+        public void testFindRootCommit() {
+            Assignment handedIn = mock(Assignment.class);
+            Assignment previous = mock(Assignment.class);
+
+            //assignments need to be in this order since sorting on mocks is a bit weird.
+            when(courseEdition.getAssignments()).thenReturn(Lists.newArrayList(previous, handedIn));
+            when(deliveries.getLastDelivery(previous, group)).thenReturn(Optional.of(delivery));
+            when(delivery.getCommit()).thenReturn(firstCommit);
+            when(delivery.getAssignment()).thenReturn(handedIn);
+
+            Optional<Commit> rootCommit = commitChecking.findRootCommit(group, delivery);
+            assertEquals(firstCommit, rootCommit.get());
+        }
+    }
+
+    public static class CommitGraphTest {
+        private Date now = new Date();
+
+        @Test
+        public void testCommitTraversalHasRightDimensions() {
+            CommitGraph graph = graphWithConsecutiveFailures();
+            List<List<Commit>> commitsTillRoot = ConsecutiveBuildFailureBackend.commitsTillRoot(graph.end, graph.root);
+
+            //we have two branches.
+            assertEquals(2, commitsTillRoot.size());
+            // the first branch has 7 commits in it.
+            assertEquals(7, commitsTillRoot.get(0).size());
+        }
+
+        @Test
+        public void testConsecutiveBuildFailures() {
+            CommitGraph graph = graphWithConsecutiveFailures();
+            List<List<Commit>> commitsTillRoot = ConsecutiveBuildFailureBackend.commitsTillRoot(graph.end, graph.root);
+            assertTrue(ConsecutiveBuildFailureBackend.consecutiveBuildFailures(commitsTillRoot));
+        }
+
+        @Test
+        public void testNoConsecutiveBuildFailures() {
+            CommitGraph graph = graphWithNoConsecutiveFailures();
+            List<List<Commit>> commitsTillRoot = ConsecutiveBuildFailureBackend.commitsTillRoot(graph.end, graph.root);
+            assertFalse(ConsecutiveBuildFailureBackend.consecutiveBuildFailures(commitsTillRoot));
+        }
+
+        /**
+         * represent the following commit graphWithConsecutiveFailures
+         * B  - D - E - F - G
+         * /                     \
+         * AD  -  C -                 HD
+         * <p>
+         * where D E F G had failures
+         * and a postfix d is a failure.
+         */
+        private CommitGraph graphWithConsecutiveFailures() {
+            Commit a = commitWithBuildResult(success(), "a");
+
+            Commit b = withBuildResultAndParent(a, success(), "b");
+            Commit c = withBuildResultAndParent(a, success(), "c");
+
+            Commit d = withBuildResultAndParent(b, failure(), "d");
+            Commit e = withBuildResultAndParent(d, failure(), "e");
+            Commit f = withBuildResultAndParent(e, failure(), "f");
+            Commit g = withBuildResultAndParent(f, failure(), "g");
+
+            Commit h = commitWithBuildResult(success(), "h");
+            h.setParents(Lists.newArrayList(g, c));
+
+            return new CommitGraph(a, h);
+        }
+
+        private CommitGraph graphWithNoConsecutiveFailures() {
+            Commit a = commitWithBuildResult(success(), "a");
+            Commit b = withBuildResultAndParent(a, success(), "b");
+
+            return new CommitGraph(a,b);
+        }
+
+        private Commit commitWithBuildResult(BuildResult result, String id) {
+            Commit commit = new Commit();
+            commit.setBuildResult(result);
+            result.setCommit(commit);
+            commit.setCommitTime(now);
+            commit.setCommitId(id);
+
+            return commit;
+        }
+
+        private Commit withBuildResultAndParent(Commit parent, BuildResult result, String id) {
+            Commit commit = commitWithBuildResult(result, id);
+            commit.setParents(Lists.newArrayList(parent));
+            return commit;
+        }
+
+        @AllArgsConstructor
+        public static class CommitGraph {
+            final Commit root;
+            final Commit end;
+        }
+
+        public static BuildResult failure() {
+            BuildResult buildResult = new BuildResult();
+            buildResult.setSuccess(false);
+            return buildResult;
+        }
+
+        public static BuildResult success() {
+            BuildResult buildResult = new BuildResult();
+            buildResult.setSuccess(true);
+            return buildResult;
+        }
+    }
+}

--- a/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResourceTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResourceTest.java
@@ -33,7 +33,7 @@ public class ProjectAssignmentsResourceTest {
 
     @Before
     public void setUp() {
-        resource = new ProjectAssignmentsResource(null, user, group, null, null, null, null, null, null);
+        resource = new ProjectAssignmentsResource(null, user, group, null, null, null, null, null, null, null);
         Mockito.when(group.getCourseEdition()).thenReturn(edition);
     }
 


### PR DESCRIPTION
Potential problems with this implementation:

When a student hands in a commit as a delivery, the commit can be in two states: Still building or finished.

The build of the final commit can change the outcome of the check.
So we check once when the delivery is made, and again when a commit that has been handed in finishes building. (Would there be any better way to combine these events?)

Also walking the commits like this is a query for every parent and might be quite slow.