### PR TITLE
Move existing rubrics to the next course edition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 		<selenium.version>2.53.0</selenium.version>
 		<build.server.version>1.2.0</build.server.version>
 		<git.server.version>1.0.10</git.server.version>
+		<assertj.version>3.6.2</assertj.version>
 	</properties>
 
     <repositories>
@@ -383,6 +384,12 @@
 			<version>1.4.1</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>${assertj.version}</version>
+		</dependency>
+
 
 		<!-- Utilities -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,7 @@
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj.version}</version>
+			<scope>test</scope>
 		</dependency>
 
 

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/embeddables/TimeSpan.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/embeddables/TimeSpan.java
@@ -5,12 +5,14 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import javax.annotation.Nullable;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
+import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.temporal.TemporalAmount;
 import java.time.temporal.TemporalUnit;
@@ -67,6 +69,23 @@ public class TimeSpan implements Serializable, Comparable<TimeSpan>, TemporalAmo
     @Override
     public java.time.temporal.Temporal subtractFrom(java.time.temporal.Temporal temporal) {
         return getDuration().subtractFrom(temporal);
+    }
+
+    /**
+     * Display the time span for the current year.
+     *
+     * @return A string showing the year the course started in.
+     *         If the end timestamp is also set it adds a -End Year aswell.
+     */
+    public String intervalString() {
+        SimpleDateFormat yearFormat = new SimpleDateFormat("YYYY");
+        String startFormat = yearFormat.format(this.start);
+
+        if (this.end != null) {
+            return startFormat + "-" + yearFormat.format(end);
+        }
+
+        return startFormat;
     }
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Assignment.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Assignment.java
@@ -43,6 +43,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Created by jgmeligmeyling on 04/03/15.
@@ -132,6 +133,26 @@ public class Assignment implements Comparable<Assignment>, Base {
 	@Override
 	public URI getURI() {
 		return getCourseEdition().getURI().resolve(ASSIGNMENTS_PATH_BASE).resolve(getAssignmentId() + "/");
+	}
+
+	public Assignment copyForNextYear(CourseEdition nextEdition, long assignmentId) {
+		final Assignment assignment = new Assignment();
+		assignment.setAssignmentId(assignmentId);
+		assignment.setCourseEdition(nextEdition);
+		assignment.setDueDate(this.getDueDate());
+		assignment.setGradesReleased(false);
+		assignment.setName(this.getName());
+		assignment.setSummary(this.getSummary());
+
+		List<Task> copyOftasks = this.getTasks().stream().map(assignment::taskforNewAssginment).collect(Collectors.toList());
+
+		assignment.setTasks(copyOftasks);
+
+		return assignment;
+	}
+
+	private Task taskforNewAssginment(Task oldTask) {
+		return oldTask.copyForNextYear(this);
 	}
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Assignment.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Assignment.java
@@ -135,20 +135,8 @@ public class Assignment implements Comparable<Assignment>, Base {
 		return getCourseEdition().getURI().resolve(ASSIGNMENTS_PATH_BASE).resolve(getAssignmentId() + "/");
 	}
 
-	public Assignment copyForNextYear(CourseEdition nextEdition, long assignmentId) {
-		final Assignment assignment = new Assignment();
-		assignment.setAssignmentId(assignmentId);
-		assignment.setCourseEdition(nextEdition);
-		assignment.setDueDate(this.getDueDate());
-		assignment.setGradesReleased(false);
-		assignment.setName(this.getName());
-		assignment.setSummary(this.getSummary());
-
-		List<Task> copyOftasks = this.getTasks().stream().map(assignment::taskforNewAssginment).collect(Collectors.toList());
-
-		assignment.setTasks(copyOftasks);
-
-		return assignment;
+	public List<Task> copyTasksFromOldAssignment(Assignment oldAssignment) {
+		return oldAssignment.getTasks().stream().map(this::taskforNewAssginment).collect(Collectors.toList());
 	}
 
 	private Task taskforNewAssginment(Task oldTask) {

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Course.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Course.java
@@ -20,6 +20,7 @@ import javax.persistence.Table;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Created by Jan-Willem on 8/11/2015.
@@ -81,14 +82,10 @@ public class Course implements Comparable<Course>, Base {
 		return URI.create(COURSE_BASE_PATH).resolve(getCode().toLowerCase() + "/");
 	}
 
-    public Optional<CourseEdition> findLastEdition() {
-        final List<CourseEdition> editions = this.getEditions();
-
-        if (editions != null) {
-            return editions.stream().max(comparing(CourseEdition::getTimeSpan));
-        }
-
-        return Optional.empty();
+    public List<Assignment> allAssignments() {
+        return this.getEditions().stream()
+                .flatMap(course -> course.getAssignments().stream())
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Course.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Course.java
@@ -81,11 +81,4 @@ public class Course implements Comparable<Course>, Base {
 	public URI getURI() {
 		return URI.create(COURSE_BASE_PATH).resolve(getCode().toLowerCase() + "/");
 	}
-
-    public List<Assignment> allAssignments() {
-        return this.getEditions().stream()
-                .flatMap(course -> course.getAssignments().stream())
-                .collect(Collectors.toList());
-    }
-
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Course.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Course.java
@@ -1,5 +1,7 @@
 package nl.tudelft.ewi.devhub.server.database.entities;
 
+import static java.util.Comparator.comparing;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -17,6 +19,7 @@ import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Created by Jan-Willem on 8/11/2015.
@@ -77,5 +80,15 @@ public class Course implements Comparable<Course>, Base {
 	public URI getURI() {
 		return URI.create(COURSE_BASE_PATH).resolve(getCode().toLowerCase() + "/");
 	}
+
+    public Optional<CourseEdition> findLastEdition() {
+        final List<CourseEdition> editions = this.getEditions();
+
+        if (editions != null) {
+            return editions.stream().max(comparing(CourseEdition::getTimeSpan));
+        }
+
+        return Optional.empty();
+    }
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/CourseEdition.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/CourseEdition.java
@@ -34,6 +34,9 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
 
 @Data
 @Entity
@@ -135,4 +138,15 @@ public class CourseEdition implements Comparable<CourseEdition>, Configurable, B
 		return URI.create("/").relativize(uri);
 	}
 
+	/**
+	 * Copies all the assignments from a previous edition from a course to the next.
+	 * @param copyFor the next version of the course edition that the assignments should be copied to.
+	 *
+	 * @return a new edition of a course with all the same assignments as the previous.
+	 */
+	public List<Assignment> copyAssignmentsForNextYear(CourseEdition copyFor) {
+		final List<Assignment> assignments = this.getAssignments();
+		return IntStream.range(0, assignments.size())
+				.mapToObj(i -> assignments.get(i).copyForNextYear(copyFor, i + 1)).collect(toList());
+	}
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/CourseEdition.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/CourseEdition.java
@@ -31,6 +31,7 @@ import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import java.net.URI;
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -136,5 +137,9 @@ public class CourseEdition implements Comparable<CourseEdition>, Configurable, B
 		URI uri = getURI().resolve("group-" + group.getGroupNumber());
 		// Relativize to "/" because repository names do not start with "/"
 		return URI.create("/").relativize(uri);
+	}
+
+	public String intervalString() {
+		return timeSpan.intervalString();
 	}
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/CourseEdition.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/CourseEdition.java
@@ -137,16 +137,4 @@ public class CourseEdition implements Comparable<CourseEdition>, Configurable, B
 		// Relativize to "/" because repository names do not start with "/"
 		return URI.create("/").relativize(uri);
 	}
-
-	/**
-	 * Copies all the assignments from a previous edition from a course to the next.
-	 * @param copyFor the next version of the course edition that the assignments should be copied to.
-	 *
-	 * @return a new edition of a course with all the same assignments as the previous.
-	 */
-	public List<Assignment> copyAssignmentsForNextYear(CourseEdition copyFor) {
-		final List<Assignment> assignments = this.getAssignments();
-		return IntStream.range(0, assignments.size())
-				.mapToObj(i -> assignments.get(i).copyForNextYear(copyFor, i + 1)).collect(toList());
-	}
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/Characteristic.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/Characteristic.java
@@ -23,6 +23,8 @@ import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import java.util.List;
 
+import static java.util.stream.Collectors.toList;
+
 /**
  * The skills, knowledge, and/or behavior to be demonstrated.
  */
@@ -101,4 +103,19 @@ public class Characteristic implements Comparable<Characteristic> {
 		return Long.compare(getId(), o.getId());
 	}
 
+	public Characteristic copyForNextYear(Task task) {
+		Characteristic newCharacteristic = new Characteristic();
+		newCharacteristic.setDescription(this.description);
+		newCharacteristic.setTask(task);
+		newCharacteristic.setWeight(this.weight);
+
+		List<Mastery> newMasteries = this.getLevels().stream().map(newCharacteristic::copyOfMastery).collect(toList());
+		newCharacteristic.setLevels(newMasteries);
+
+		return newCharacteristic;
+	}
+
+	private Mastery copyOfMastery(Mastery mastery) {
+		return mastery.copyForNextYear(this);
+	}
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/Mastery.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/Mastery.java
@@ -70,4 +70,12 @@ public class Mastery implements Comparable<Mastery> {
 		return mastery;
 	}
 
+	public Mastery copyForNextYear(Characteristic characteristic) {
+		final Mastery mastery = new Mastery();
+		mastery.setCharacteristic(characteristic);
+		mastery.setDescription(this.description);
+		mastery.setPoints(this.points);
+
+		return mastery;
+	}
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/Task.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/Task.java
@@ -6,10 +6,8 @@ import lombok.ToString;
 import nl.tudelft.ewi.devhub.server.database.entities.Assignment;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
-import com.google.common.collect.ComparisonChain;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -25,6 +23,8 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * A subtask of an {@link Assignment}.
@@ -83,4 +83,17 @@ public class Task implements Comparable<Task> {
 		return Long.compare(getId(), o.getId());
 	}
 
+	public Task copyForNextYear(Assignment assignment) {
+		final Task newTask = new Task();
+		newTask.setAssignment(assignment);
+		newTask.setDescription(this.description);
+		List<Characteristic> copyOfCharacteristics = this.getCharacteristics().stream().map(newTask::copyCharacteristic).collect(toList());
+		newTask.setCharacteristics(copyOfCharacteristics);
+
+		return newTask;
+	}
+
+	private Characteristic copyCharacteristic(Characteristic characteristic) {
+		return characteristic.copyForNextYear(this);
+	}
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/AssignmentsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/AssignmentsResource.java
@@ -32,7 +32,6 @@ import com.google.inject.persist.Transactional;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.jboss.resteasy.spi.NotImplementedYetException;
-import org.jboss.weld.exceptions.IllegalArgumentException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -55,7 +54,6 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -162,10 +160,10 @@ public class AssignmentsResource extends Resource {
 			throw new UnauthorizedException();
 		}
 
-		return copyableAssignmentsPerEdition(courseEdition.getCourse());
+		return copyableCourseEditionsFromCourse(courseEdition.getCourse());
 	}
 
-	private static List<CopyableCourseEdition> copyableAssignmentsPerEdition(Course course) {
+	private static List<CopyableCourseEdition> copyableCourseEditionsFromCourse(Course course) {
     	return course.getEditions().stream()
 				.map(edition -> new CopyableCourseEdition(edition, copyableAssignmentsFromEdition(edition)))
 				.collect(Collectors.toList());
@@ -214,7 +212,8 @@ public class AssignmentsResource extends Resource {
     public Response createPage(@PathParam("courseCode") String courseCode,
 							   @PathParam("editionCode") String editionCode,
                                @FormParam("id") Long assignmentId,
-                               @FormParam("rubricsToCopy") String rubricsToCopy,
+                               @FormParam("courseEditionToCopyFromId") String courseEditionToCopyFromId,
+							   @FormParam("assignmentToCopyFromId") String assignmentToCopyFromId,
                                @FormParam("name") String name,
                                @FormParam("summary") String summary,
                                @FormParam("due-date") String dueDate) {
@@ -234,9 +233,7 @@ public class AssignmentsResource extends Resource {
         assignment.setName(name);
         assignment.setSummary(summary);
 
-		List<Task> tasks = RubricIds.fromForm(rubricsToCopy)
-				.map(r -> this.tasksForNewAssignment(assignment, r))
-				.orElseGet(ArrayList::new);
+		List<Task> tasks = this.tasksForNewAssignment(assignment, courseEditionToCopyFromId, assignmentToCopyFromId);
 
         assignment.setTasks(tasks);
 
@@ -267,39 +264,19 @@ public class AssignmentsResource extends Resource {
         return redirect(course.getURI());
     }
 
-    private List<Task> tasksForNewAssignment(Assignment newAssignment ,RubricIds ids) {
-		CourseEdition editionToGetRubricsFrom = courses.find(ids.getAssignmentId());
-		Assignment assignmentToCopyRubricsFrom = assignmentsDAO.find(editionToGetRubricsFrom, ids.getAssignmentId());
+    private List<Task> tasksForNewAssignment(Assignment newAssignment, String courseEditionId, String assignmentId) {
+    	try {
+    		long courseEdition = Long.parseLong(courseEditionId);
+    		long assignment = Long.parseLong(assignmentId);
 
-		return newAssignment.copyTasksFromOldAssignment(assignmentToCopyRubricsFrom);
-	}
+			CourseEdition editionToGetRubricsFrom = courses.find(courseEdition);
+			Assignment assignmentToCopyRubricsFrom = assignmentsDAO.find(editionToGetRubricsFrom, assignment);
 
-    @Value
-    private static class RubricIds {
-    	private long courseEdition;
-    	private long assignmentId;
-
-		/**
-		 * Decode the rubric migration form parameter to the actual course edition and assignment id.
-		 *
-		 * @param rubricsToCopy the string from the form.
-		 * @return {@code Optional.empty()} if the form string was empty, we don't want to migrate rubrics in that case.
-		 * 			otherwise an optional containing the course edition and assignmentId.
-		 */
-    	static Optional<RubricIds> fromForm(String rubricsToCopy) {
-    		if (rubricsToCopy.isEmpty()) {
-    			return Optional.empty();
-			}
-
-			String[] ids = rubricsToCopy.split("-");
-			if (ids.length != 2) {
-				throw new IllegalArgumentException("the rubrics format should be courseEdition-assginmentId");
-			}
-
-			return Optional.of(new RubricIds(Long.parseLong(ids[0]), Long.parseLong(ids[1])));
+			return newAssignment.copyTasksFromOldAssignment(assignmentToCopyRubricsFrom);
+    	} catch (NumberFormatException e) {
+			return Lists.newArrayList();
 		}
 	}
-
 
     /**
      * An overview page for an assignment

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/CoursesResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/CoursesResource.java
@@ -1,6 +1,5 @@
 package nl.tudelft.ewi.devhub.server.web.resources;
 
-import com.google.common.base.Strings;
 import lombok.extern.slf4j.Slf4j;
 import nl.tudelft.ewi.devhub.server.backend.CoursesBackend;
 import nl.tudelft.ewi.devhub.server.database.controllers.CourseEditions;
@@ -8,7 +7,6 @@ import nl.tudelft.ewi.devhub.server.database.controllers.Courses;
 import nl.tudelft.ewi.devhub.server.database.embeddables.TimeSpan;
 import nl.tudelft.ewi.devhub.server.database.entities.Course;
 import nl.tudelft.ewi.devhub.server.database.entities.CourseEdition;
-import nl.tudelft.ewi.devhub.server.database.entities.Group;
 import nl.tudelft.ewi.devhub.server.database.entities.User;
 import nl.tudelft.ewi.devhub.server.database.entities.builds.MavenBuildInstructionEntity;
 import nl.tudelft.ewi.devhub.server.web.errors.UnauthorizedException;
@@ -19,7 +17,6 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.google.inject.servlet.RequestScoped;
 
-import javax.persistence.EntityNotFoundException;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -35,7 +32,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -341,5 +337,5 @@ public class CoursesResource extends Resource {
 
         return redirect(Course.COURSE_BASE_PATH + courseCode);
     }
-
+    
 }

--- a/src/main/resources/i18n/devhub_en.properties
+++ b/src/main/resources/i18n/devhub_en.properties
@@ -26,6 +26,9 @@ form.login.password.label = Password
 form.login.title = Login
 
 assignments.title = Assignments
+assignment.rubric.from-assignment = From assignment
+assignment.rubric.from-course-edition = Rubrics from course edition
+
 
 form.project-setup.buttons.finish.caption = Create group
 form.project-setup.buttons.next.caption = Next

--- a/src/main/resources/i18n/devhub_en.properties
+++ b/src/main/resources/i18n/devhub_en.properties
@@ -61,6 +61,7 @@ error.could-not-comment = Comment could not be persisted
 error.could-not-deliver = Assignment could not be delivered
 error.could-not-review = Review could not be persisted
 error.course-create-error = Course could not be created
+error.courseEdition-create-error = CourseEdition could not be created
 error.course-name-empty = Course name should not be empty
 error.course-code-empty = Course code should not be empty
 error.course-min-group-empty = Min group size should not be empty

--- a/src/main/resources/templates/courses/assignments/create-assignment.ftl
+++ b/src/main/resources/templates/courses/assignments/create-assignment.ftl
@@ -1,7 +1,7 @@
 [#import "../../macros.ftl" as macros]
 [@macros.renderHeader i18n.translate("assignments.title") /]
 [@macros.renderMenu i18n user /]
-<div class="container">
+<div class="container" ng-controller="rubricController">
 <h2>${i18n.translate("assignment.create")}</h2>
 <form class="form-horizontal" method="POST" target="_self" action="">
 
@@ -19,7 +19,7 @@
         </div>
     </div>
 
-    [#if assignment?exists]
+    [#if assignment??]
         [#assign assignmentNumber = assignment.assignmentId]
     [#else]
         [#assign assignmentNumber = course.getAssignments()?size + 1]
@@ -31,7 +31,7 @@
         <label for="due-date" class="col-sm-2 control-label">${i18n.translate("course.control.due-date")}</label>
         <div class="col-sm-10">
             <input type="text" class="form-control" name="due-date" id="due-date"
-               [#if assignment?exists && assignment.getDueDate()??]
+               [#if assignment?? && assignment.getDueDate()??]
                    value="${assignment.getDueDate()?string["dd-MM-yyyy HH:mm"]}"
                [#else]
                    value="${.now?string["dd-MM-yyyy HH:mm"]}"
@@ -41,23 +41,35 @@
     </div>
 
 
-    [#if !assignment?? && existingAssignments??]
+    [#if !assignment??]
 
     <div class="form-group">
-        <label for="existing-rubrics" class="col-sm-2 control-label">Existing Rubrics</label>
+        <label for="existing-rubrics-from-course" class="col-sm-2 control-label">Rubrics from course edition</label>
         <div class="col-sm-10">
-            <select class="form-control"  name="rubricsToCopy" id="existing-rubrics">
+            <select class="form-control"  ng-model="courseEdition" ng-change="newEditionSelected()" name="rubricsToCopy" id="existing-rubrics-from-course">
+                [#--<option ng-repeat="edition in"></option>--]
+                    <option></option>
                 <option></option>
-                [#list existingAssignments as assignment]
-                    [#assign timeSpan = assignment.getCourseEdition().getTimeSpan()]
-                    <option value="${assignment.getCourseEdition().getId()}-${assignment.getAssignmentId()}">${assignment.getName() + " "+timeSpan.start?string["yyyy"]}[#if timeSpan.end??] - ${timeSpan.end?string["yyyy"]}[/#if]</option>
-                [/#list]
+            </select>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <label for="existing-rubrics" class="col-sm-2 control-label">From assignment</label>
+        <div class="col-sm-10">
+            <select class="form-control" ng-model="assignmentId" ng-change="newEditionSelected()" name="rubricsToCopy" id="existing-rubrics">
+                <option></option>
+                <option></option>
+                [#--[#list existingAssignments as assignment]--]
+                    [#--[#assign timeSpan = assignment.getCourseEdition().getTimeSpan()]--]
+                    [#--<option value="${assignment.getCourseEdition().getId()}-${assignment.getAssignmentId()}">${assignment.getName() + " "+timeSpan.start?string["yyyy"]}[#if timeSpan.end??] - ${timeSpan.end?string["yyyy"]}[/#if]</option>--]
+                [#--[/#list]--]
             </select>
         </div>
     </div>
     [/#if]
 
-    [#if assignment?exists]
+    [#if assignment??]
     <div class="form-group">
         <label for="release" class="col-sm-2 control-label">${i18n.translate("assignment.release")}</label>
         <div class="col-sm-10">
@@ -69,7 +81,7 @@
     <div class="form-group">
         <label for="name" class="col-sm-2 control-label">${i18n.translate("course.control.assignment-name")}</label>
         <div class="col-sm-10">
-        [#if assignment?exists]
+        [#if assignment??]
             <input type="text" class="form-control" name="name" id="name" placeholder="${i18n.translate("course.control.assignment-name", assignmentNumber)}" value="${assignment.getName()}">
         [#else]
             <input type="text" class="form-control" name="name" id="name" placeholder="${i18n.translate("course.control.assignment-name", assignmentNumber)}">
@@ -80,7 +92,7 @@
     <div class="form-group">
         <label for="summary" class="col-sm-2 control-label">${i18n.translate("course.control.summary")}</label>
         <div class="col-sm-10">
-        [#if assignment?exists]
+        [#if assignment??]
             <textarea rows="8" class="form-control" name="summary" id="summary" placeholder="${i18n.translate("course.control.summary")}">[#if assignment.getSummary()??]${assignment.getSummary()}[/#if]</textarea>
         [#else]
             <textarea rows="8" class="form-control" name="summary" id="summary" placeholder="${i18n.translate("course.control.summary")}"></textarea>
@@ -91,7 +103,7 @@
     <div class="form-group">
         <div class="col-sm-offset-2 col-sm-10">
             <div class="pull-right">
-            [#if assignment?exists]
+            [#if assignment??]
                 <a href="${course.getURI()}" class="btn btn-default">${i18n.translate("course.control.cancel")}</a>
                 <button type="submit" class="btn btn-primary">${i18n.translate("course.control.save")}</button>
             [#else]

--- a/src/main/resources/templates/courses/assignments/create-assignment.ftl
+++ b/src/main/resources/templates/courses/assignments/create-assignment.ftl
@@ -46,10 +46,8 @@
     <div class="form-group">
         <label for="existing-rubrics-from-course" class="col-sm-2 control-label">Rubrics from course edition</label>
         <div class="col-sm-10">
-            <select class="form-control"  ng-model="courseEdition" ng-change="newEditionSelected()" name="rubricsToCopy" id="existing-rubrics-from-course">
-                [#--<option ng-repeat="edition in"></option>--]
-                    <option></option>
-                <option></option>
+            <select class="form-control" ng-model="courseEdition" name="courseEditionToCopyFromId" id="existing-rubrics-from-course"
+                    ng-options="edition as edition.name for edition in courseEditions track by edition.courseEdition">
             </select>
         </div>
     </div>
@@ -57,13 +55,8 @@
     <div class="form-group">
         <label for="existing-rubrics" class="col-sm-2 control-label">From assignment</label>
         <div class="col-sm-10">
-            <select class="form-control" ng-model="assignmentId" ng-change="newEditionSelected()" name="rubricsToCopy" id="existing-rubrics">
-                <option></option>
-                <option></option>
-                [#--[#list existingAssignments as assignment]--]
-                    [#--[#assign timeSpan = assignment.getCourseEdition().getTimeSpan()]--]
-                    [#--<option value="${assignment.getCourseEdition().getId()}-${assignment.getAssignmentId()}">${assignment.getName() + " "+timeSpan.start?string["yyyy"]}[#if timeSpan.end??] - ${timeSpan.end?string["yyyy"]}[/#if]</option>--]
-                [#--[/#list]--]
+            <select class="form-control" ng-model="selectedAssignment" name="assignmentToCopyFromId" id="existing-rubrics"
+                    ng-options="assignment as assignment.name for assignment in courseEdition.assignments track by assignment.assignmentId">
             </select>
         </div>
     </div>
@@ -84,7 +77,7 @@
         [#if assignment??]
             <input type="text" class="form-control" name="name" id="name" placeholder="${i18n.translate("course.control.assignment-name", assignmentNumber)}" value="${assignment.getName()}">
         [#else]
-            <input type="text" class="form-control" name="name" id="name" placeholder="${i18n.translate("course.control.assignment-name", assignmentNumber)}">
+            <input type="text" class="form-control" name="name" id="name" placeholder="${i18n.translate("course.control.assignment-name", assignmentNumber)}" value="{{selectedAssignment.name}}">
         [/#if]
         </div>
     </div>
@@ -95,7 +88,7 @@
         [#if assignment??]
             <textarea rows="8" class="form-control" name="summary" id="summary" placeholder="${i18n.translate("course.control.summary")}">[#if assignment.getSummary()??]${assignment.getSummary()}[/#if]</textarea>
         [#else]
-            <textarea rows="8" class="form-control" name="summary" id="summary" placeholder="${i18n.translate("course.control.summary")}"></textarea>
+            <textarea rows="8" class="form-control" name="summary" id="summary" placeholder="${i18n.translate("course.control.summary")}">{{selectedAssignment.summary}}</textarea>
         [/#if]
         </div>
     </div>
@@ -116,5 +109,21 @@
 
 </form>
 </div>
+
+[#if !assignment??]
+<script src="/static/vendor/angular/angular.js"></script>
+<script>
+    var module = angular.module("devhub", []);
+    module.controller("rubricController", function($scope, $http) {
+        $scope.courseEditions = [];
+
+        var assignmentData = $http.get("create/bliep").success(function(data) {
+            $scope.courseEditions = data;
+        });
+    })
+
+</script>
+[/#if]
+
 [@macros.renderScripts /]
 [@macros.renderFooter /]

--- a/src/main/resources/templates/courses/assignments/create-assignment.ftl
+++ b/src/main/resources/templates/courses/assignments/create-assignment.ftl
@@ -44,7 +44,7 @@
     [#if !assignment??]
 
     <div class="form-group">
-        <label for="existing-rubrics-from-course" class="col-sm-2 control-label">Rubrics from course edition</label>
+        <label for="existing-rubrics-from-course" class="col-sm-2 control-label">${i18n.translate("assignment.rubric.from-course-edition")}</label>
         <div class="col-sm-10">
             <select class="form-control" ng-model="courseEdition" name="courseEditionToCopyFromId" id="existing-rubrics-from-course"
                     ng-options="edition as edition.name for edition in courseEditions track by edition.courseEdition">
@@ -53,7 +53,7 @@
     </div>
 
     <div class="form-group">
-        <label for="existing-rubrics" class="col-sm-2 control-label">From assignment</label>
+        <label for="existing-rubrics" class="col-sm-2 control-label">${i18n.translate("assignment.rubric.from-assignment")}</label>
         <div class="col-sm-10">
             <select class="form-control" ng-model="selectedAssignment" name="assignmentToCopyFromId" id="existing-rubrics"
                     ng-options="assignment as assignment.name for assignment in courseEdition.assignments track by assignment.assignmentId">

--- a/src/main/resources/templates/courses/assignments/create-assignment.ftl
+++ b/src/main/resources/templates/courses/assignments/create-assignment.ftl
@@ -40,6 +40,23 @@
         </div>
     </div>
 
+
+    [#if !assignment?? && existingAssignments??]
+
+    <div class="form-group">
+        <label for="existing-rubrics" class="col-sm-2 control-label">Existing Rubrics</label>
+        <div class="col-sm-10">
+            <select class="form-control"  name="rubricsToCopy" id="existing-rubrics">
+                <option></option>
+                [#list existingAssignments as assignment]
+                    [#assign timeSpan = assignment.getCourseEdition().getTimeSpan()]
+                    <option value="${assignment.getCourseEdition().getId()}-${assignment.getAssignmentId()}">${assignment.getName() + " "+timeSpan.start?string["yyyy"]}[#if timeSpan.end??] - ${timeSpan.end?string["yyyy"]}[/#if]</option>
+                [/#list]
+            </select>
+        </div>
+    </div>
+    [/#if]
+
     [#if assignment?exists]
     <div class="form-group">
         <label for="release" class="col-sm-2 control-label">${i18n.translate("assignment.release")}</label>

--- a/src/test/java/nl/tudelft/ewi/devhub/server/database/embeddables/TimeSpanTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/database/embeddables/TimeSpanTest.java
@@ -1,0 +1,35 @@
+package nl.tudelft.ewi.devhub.server.database.embeddables;
+
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TimeSpanTest {
+	@Test
+	public void courseThatEnded() {
+		LocalDateTime thisYear = LocalDateTime.of(2017,1,1,0,0);
+		LocalDateTime oneYearFromNow = thisYear.plusYears(1);
+
+		TimeSpan timeSpan = new TimeSpan(fromLocalDateTime(thisYear), fromLocalDateTime(oneYearFromNow));
+		assertThat(timeSpan.intervalString()).isEqualTo("2017-2018");
+	}
+
+	@Test
+	public void courseThatOnlyHasStart() {
+		LocalDateTime thisYear = LocalDateTime.of(2017,1,1,0,0);
+		TimeSpan timeSpan = new TimeSpan();
+		timeSpan.setStart(fromLocalDateTime(thisYear));
+
+		assertThat(timeSpan.intervalString()).isEqualTo("2017");
+	}
+
+
+	private static Date fromLocalDateTime(LocalDateTime localDateTime) {
+		return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+	}
+
+}

--- a/src/test/java/nl/tudelft/ewi/devhub/server/database/entities/AssignmentUnitTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/database/entities/AssignmentUnitTest.java
@@ -3,8 +3,11 @@ package nl.tudelft.ewi.devhub.server.database.entities;
 import static nl.tudelft.ewi.devhub.server.database.entities.rubrics.TaskTest.taskWithOneCharacteristic;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import nl.tudelft.ewi.devhub.server.database.entities.rubrics.Task;
 import org.assertj.core.util.Lists;
 import org.junit.Test;
+
+import java.util.List;
 
 public class AssignmentUnitTest {
 
@@ -12,11 +15,11 @@ public class AssignmentUnitTest {
 	public void testAssignmentCopy() {
 		final Assignment assignment = assignmentWithOneTask();
 		CourseEdition courseEdition = new CourseEdition();
-		final Assignment newAssignment = assignment.copyForNextYear(courseEdition, 1);
+		Assignment newAssignment = new Assignment();
 
-		assertThat(newAssignment.getAssignmentId()).isEqualTo(1);
-		assertThat(newAssignment.getCourseEdition()).isSameAs(courseEdition);
-		assertThat(newAssignment.isGradesReleased()).isFalse();
+		List<Task> tasks = newAssignment.copyTasksFromOldAssignment(assignment);
+
+		assertThat(tasks).allMatch(t -> t.getAssignment().equals(newAssignment));
 	}
 
 	private Assignment assignmentWithOneTask() {

--- a/src/test/java/nl/tudelft/ewi/devhub/server/database/entities/AssignmentUnitTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/database/entities/AssignmentUnitTest.java
@@ -1,0 +1,28 @@
+package nl.tudelft.ewi.devhub.server.database.entities;
+
+import static nl.tudelft.ewi.devhub.server.database.entities.rubrics.TaskTest.taskWithOneCharacteristic;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.util.Lists;
+import org.junit.Test;
+
+public class AssignmentUnitTest {
+
+	@Test
+	public void testAssignmentCopy() {
+		final Assignment assignment = assignmentWithOneTask();
+		CourseEdition courseEdition = new CourseEdition();
+		final Assignment newAssignment = assignment.copyForNextYear(courseEdition, 1);
+
+		assertThat(newAssignment.getAssignmentId()).isEqualTo(1);
+		assertThat(newAssignment.getCourseEdition()).isSameAs(courseEdition);
+		assertThat(newAssignment.isGradesReleased()).isFalse();
+	}
+
+	private Assignment assignmentWithOneTask() {
+		final Assignment assignment = new Assignment();
+
+		assignment.setTasks(Lists.newArrayList(taskWithOneCharacteristic()));
+		return assignment;
+	}
+}

--- a/src/test/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/CharacteristicTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/CharacteristicTest.java
@@ -1,0 +1,42 @@
+package nl.tudelft.ewi.devhub.server.database.entities.rubrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.util.Lists;
+import org.junit.Test;
+
+public class CharacteristicTest {
+
+	@Test
+	public void testCopyOfCharacteristic() {
+		Task task = new Task();
+
+		Characteristic characteristic = characteristicWithOneMastery();
+		final Characteristic newCharacteristic = characteristic.copyForNextYear(task);
+
+		assertThat(newCharacteristic).isNotSameAs(characteristic);
+		assertThat(newCharacteristic.getDescription()).isEqualTo("A characteristic");
+		assertThat(newCharacteristic.getWeight()).isEqualTo(10);
+		assertThat(newCharacteristic.getId()).isEqualTo(0);
+		assertThat(newCharacteristic.getLevels().stream().map(Mastery::getCharacteristic))
+				.are(forTheNewCharacteristic(newCharacteristic));
+	}
+
+	private static Condition<Characteristic> forTheNewCharacteristic(Characteristic newCharacteristic) {
+		return new Condition<>(c -> {
+			assertThat(c).isSameAs(newCharacteristic);
+			return true;
+		},"It should be the same instance as the newCharacteristic");
+	}
+
+	static Characteristic characteristicWithOneMastery() {
+		Characteristic characteristic = new Characteristic();
+
+		characteristic.setLevels(Lists.newArrayList(new Mastery()));
+		characteristic.setDescription("A characteristic");
+		characteristic.setWeight(10);
+
+		return characteristic;
+	 }
+}

--- a/src/test/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/TaskTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/TaskTest.java
@@ -1,0 +1,37 @@
+package nl.tudelft.ewi.devhub.server.database.entities.rubrics;
+
+import static nl.tudelft.ewi.devhub.server.database.entities.rubrics.CharacteristicTest.characteristicWithOneMastery;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.util.Lists;
+import org.junit.Test;
+
+public class TaskTest {
+
+	@Test
+	public void testCopyOfTask() {
+		final Task task = taskWithOneCharacteristic();
+		final Task newTask = task.copyForNextYear(null);
+
+		assertThat(newTask.getDescription()).isEqualTo("A task");
+		assertThat(newTask.getId()).isEqualTo(0);
+		assertThat(newTask.getCharacteristics().stream().map(Characteristic::getTask)).are(forTheTask(newTask));
+	}
+
+	 public static Task taskWithOneCharacteristic() {
+		final Task task = new Task();
+
+		task.setDescription("A task");
+		task.setId(4);
+		task.setCharacteristics(Lists.newArrayList(characteristicWithOneMastery()));
+		return task;
+	}
+
+	private static Condition<Task> forTheTask(Task newTask) {
+		return new Condition<>(t -> {
+			assertThat(t).isSameAs(newTask);
+			return true;
+		},"It should be the same instance as the newTask");
+	}
+}


### PR DESCRIPTION
If a course already had a previous edition we add the same rubrics
to the next edition.

Give the assignments an id to solve the ID generation deadlock.
Persist the course edition first then add the assignments.

The courseEdition-create-error was being referenced from a controller,
but not actually present in the translation file.

Also pulled in assertJ for writing tests.

fixes #420