### PR TITLE
Fix the webtests by upgrading Selenium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
 sudo: required
 dist: trusty
+# cache the dependency-check-maven plugin catalog (280MB+)
+cache:
+  directories: $HOME/.m2/repository/org/owasp/dependency-check-data/
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ addons:
   apt:
     packages:
       - oracle-java8-installer
+      - google-chrome-stable
+    sources:
+      - google-chrome
 jdk:
   - oraclejdk8
 before_install:
+  - "which chromedriver"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ addons:
 jdk:
   - oraclejdk8
 before_install:
+  - sudo apt-get install chromium-chromedriver
+before_script:
+  - "export PATH=$PATH:/usr/lib/chromium-browser/"
+  - "which chromedriver"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
 jdk:
   - oraclejdk8
 before_install:
-  - "which chromedriver"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: java
 sudo: required
 dist: trusty
-# cache the dependency-check-maven plugin catalog (280MB+)
 cache:
-  directories: $HOME/.m2/repository/org/owasp/dependency-check-data/
+  directories: $HOME/.m2/
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
-sudo: trusty
+sudo: required
+dist: trusty
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-sudo: false
+sudo: trusty
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
   - sudo apt-get install chromium-chromedriver
 before_script:
   - "export PATH=$PATH:/usr/lib/chromium-browser/"
-  - "which chromedriver"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,14 @@ To successfully run and test Devhub, a couple of steps should be followed to set
 		1. Install "Lombok Plugin"
 		
 When the JPA plugin for Eclipse generates a lot of false errors, you can disable the validation under `Preferences > Validation > JPA Validator`.
-		
+
+### Running integration tests
+
+If you want to run the integration tests (which are the webtests), run the following command:
+`mvn integration-test`
+
+For this, you will need to download a separate Chrome driver to run the test in a browser. You can find the driver at https://sites.google.com/a/chromium.org/chromedriver/downloads
+
 ### Code Formatting
 We do not write getters/setters and equals/hashcode implementations ourselves, but instead use the Lombok `@Data` and `@EqualsAndHashcode` annotations for that. Prevent overuse of Lombok, try to limit it to JPA classes and Jackson models.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ To successfully run and test Devhub, a couple of steps should be followed to set
 		
 When the JPA plugin for Eclipse generates a lot of false errors, you can disable the validation under `Preferences > Validation > JPA Validator`.
 
-### Running integration tests
+### Running the webtests
 
 If you want to run the integration tests (which are the webtests), run the following command:
 `mvn integration-test`

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<liquibase.slf4j.version>1.7.7</liquibase.slf4j.version>
 		<querydsl.version>3.6.0</querydsl.version>
 		<logback.version>1.1.11</logback.version>
-		<selenium.version>2.53.0</selenium.version>
+		<selenium.version>3.0.0</selenium.version>
 		<build.server.version>1.2.0</build.server.version>
 		<git.server.version>1.0.10</git.server.version>
 	</properties>
@@ -361,7 +361,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-firefox-driver</artifactId>
+			<artifactId>selenium-chrome-driver</artifactId>
 			<version>${selenium.version}</version>
 			<scope>test</scope>
 			<exclusions>

--- a/src/test/java/nl/tudelft/ewi/devhub/webtests/rules/DriverResource.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/webtests/rules/DriverResource.java
@@ -2,7 +2,7 @@ package nl.tudelft.ewi.devhub.webtests.rules;
 
 import org.junit.rules.ExternalResource;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -19,7 +19,7 @@ public class DriverResource extends ExternalResource {
 
 	@Override
 	protected void before() throws Throwable {
-		WebDriver driver = new FirefoxDriver();
+		WebDriver driver = new ChromeDriver();
 		driver.manage().window().maximize();
 		driverRef.set(driver);
 	}


### PR DESCRIPTION
The webtests were not running anymore, as the Selenium drivers were not compatible with the latest versions of Firefox. Therefore, the fix is to upgrade Selenium to 3.x and use the Chrome driver instead of the Firefox driver.

I have added build instructions to the `CONTRIBUTING.md` and migrated the webtests code. Note that we can not rely on Selenium 3.3.1, as that has a dependency on `Guava:21.0` which is incompatible with most of the other code (other devhub dependencies as well as querydsl).

Let's see if this thing passes on CI.