### PR TITLE
Enforce LF line endings to avoid whitespace issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This makes it easier to review, because some files were edited on a Windows machine (thus CRLF line endings), while others are edited on a Unix machine (thus LF line endings). The file makes sure that all future files will be edited with LF line endings.