### PR TITLE
Ensure rubrics filled in

### DIFF
--- a/src/main/resources/templates/courses/assignments/group-delivery-review.ftl
+++ b/src/main/resources/templates/courses/assignments/group-delivery-review.ftl
@@ -123,17 +123,24 @@
 <script type="text/javascript">
 	function computeTotals() {
 		var total = 0;
+        $('[type="submit"]').disabled = false;
+
 		$('.task').each(function(i, taskElement) {
 			var task = $(taskElement).data();
 			task.total = 0;
 
-			$(taskElement).find('.characteristic').each(function(i, characteristicElement) {
+            $(taskElement).find('.characteristic').each(function(i, characteristicElement) {
 				var characteristic = $(characteristicElement).data();
 
-                $(characteristicElement).find('[type="radio"]:checked').each(function(i, checkedMasteryElement) {
+                var masteries = $(characteristicElement).find('[type="radio"]:checked');
+                masteries.each(function(i, checkedMasteryElement) {
 					var level = $(checkedMasteryElement).data();
 					characteristic.points = level.points * characteristic.weight;
 				});
+
+                if (masteries.length === 0) {
+                    $('[type="submit"]').disabled = true;
+				}
 
 				task.total += characteristic.points || 0;
 				$(characteristicElement).find('#lbl-total-characteristic-' + characteristic.id).text(characteristic.points);

--- a/src/main/resources/templates/courses/assignments/group-delivery-review.ftl
+++ b/src/main/resources/templates/courses/assignments/group-delivery-review.ftl
@@ -123,7 +123,7 @@
 <script type="text/javascript">
 	function computeTotals() {
 		var total = 0;
-        $('[type="submit"]').disabled = false;
+        $('[type="submit"]').prop('disabled', false);
 
 		$('.task').each(function(i, taskElement) {
 			var task = $(taskElement).data();
@@ -139,7 +139,7 @@
 				});
 
                 if (masteries.length === 0) {
-                    $('[type="submit"]').disabled = true;
+                    $('[type="submit"]').prop('disabled', true);
 				}
 
 				task.total += characteristic.points || 0;

--- a/src/test/java/nl/tudelft/ewi/devhub/webtests/views/DeliveryReviewView.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/webtests/views/DeliveryReviewView.java
@@ -12,6 +12,7 @@ import org.openqa.selenium.support.ui.Select;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -170,6 +171,17 @@ public class DeliveryReviewView extends ProjectSidebarView {
         public DeliveryReviewView click() {
             anchor.click();
             return new DeliveryReviewView(getDriver());
+        }
+
+        public List<WebElement> getFirstMasteryForEachCharacteristic() {
+            return getDriver().findElements(By.cssSelector(".characteristic"))
+                    .stream()
+                    .map((e) -> e.findElement(By.cssSelector("[type='radio']")))
+                    .collect(Collectors.toList());
+        }
+
+        public boolean isSubmitButtonDisabled() {
+            return "true".equals(anchor.getAttribute("disabled"));
         }
 
     }


### PR DESCRIPTION
:pear:ed with @LiamClark 

After filling in all masteries, the submit button should now be clickable.

Fixes #381 