### PR TITLE
Upgrade Mockito to 2.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.8.3</version>
+			<version>2.7.22</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -355,8 +355,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.10.8</version>
+			<artifactId>mockito-core</artifactId>
+			<version>2.8.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -380,7 +380,7 @@
 		<dependency>
 			<groupId>org.jukito</groupId>
 			<artifactId>jukito</artifactId>
-			<version>1.4.1</version>
+			<version>1.5</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/test/java/nl/tudelft/ewi/devhub/modules/MockedGitoliteGitServerModule.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/modules/MockedGitoliteGitServerModule.java
@@ -126,7 +126,6 @@ public class MockedGitoliteGitServerModule extends AbstractModule {
 	protected void createMockedRepositoriesFolder() {
 		String repositoriesPath = repositoriesFolder.toPath().toString() + "/";
 		when(configuration.getGitoliteBaseUrl()).thenReturn(repositoriesPath);
-		when(configuration.getRepositoriesDirectory()).thenReturn(repositoriesFolder);
 		log.info("Initialized bare repository folder in {}", repositoriesPath);
 	}
 

--- a/src/test/java/nl/tudelft/ewi/devhub/modules/MockedGitoliteGitServerModule.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/modules/MockedGitoliteGitServerModule.java
@@ -126,6 +126,7 @@ public class MockedGitoliteGitServerModule extends AbstractModule {
 	protected void createMockedRepositoriesFolder() {
 		String repositoriesPath = repositoriesFolder.toPath().toString() + "/";
 		when(configuration.getGitoliteBaseUrl()).thenReturn(repositoriesPath);
+        when(configuration.getRepositoriesDirectory()).thenReturn(repositoriesFolder);
 		log.info("Initialized bare repository folder in {}", repositoriesPath);
 	}
 

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/BuildsBackendTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/BuildsBackendTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.concurrent.Executors;
 

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/CourseBackendTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/CourseBackendTest.java
@@ -14,15 +14,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.Matchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +63,7 @@ public class CourseBackendTest extends BackendTest {
 		course.setAssistants(oldAssistants);
 		
 		when(currentUser.isAdmin()).thenReturn(true);
-		when(groups.getGroup(Matchers.any())).thenReturn(groupApi);
+		when(groups.getGroup(any())).thenReturn(groupApi);
 
 	}
 
@@ -94,7 +95,7 @@ public class CourseBackendTest extends BackendTest {
 	@SuppressWarnings("unchecked")
 	@Test(expected=Exception.class)
 	public void courseIsRemovedWhenFailedToStore() {
-		when(courses.persist(Matchers.eq(course))).thenThrow(Exception.class);
+		when(courses.persist(eq(course))).thenThrow(Exception.class);
 		
 		courseBackend.createCourse(course);
 	}

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/DeliveriesBackendTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/DeliveriesBackendTest.java
@@ -112,8 +112,6 @@ public class DeliveriesBackendTest extends BackendTest {
 		when(storageBackend.store(Matchers.anyString(), Matchers.eq(fileName), Matchers.eq(in))).thenReturn(FULL_PATH_NAME);
 		when(storageBackend.getFile(Matchers.eq(FULL_PATH_NAME))).thenReturn(file);
 		
-		when(deliveriesDAO.getDeliveries(Matchers.eq(assignment), Matchers.eq(group))).thenReturn(deliveries);
-		
 		when(attachment.getPath()).thenReturn(FULL_PATH_NAME);
 
 		when(deliveriesDAO.getLastDelivery(Matchers.eq(assignment), Matchers.eq(group))).thenReturn(Optional.empty());
@@ -136,7 +134,6 @@ public class DeliveriesBackendTest extends BackendTest {
 	}
 
 	private void isAnAdmin() {
-		when(currentUser.isAssisting(Matchers.eq(courseEdition))).thenReturn(false);
 		when(group.getMembers()).thenReturn(Sets.newHashSet());
 	}
 	

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/DeliveriesBackendTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/DeliveriesBackendTest.java
@@ -20,10 +20,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,6 +33,8 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -99,7 +100,7 @@ public class DeliveriesBackendTest extends BackendTest {
 		deliveries = Lists.newArrayList(delivery);
 		
 		when(currentUser.isAdmin()).thenReturn(true);
-		when(currentUser.isAssisting(Matchers.eq(courseEdition))).thenReturn(true);
+		when(currentUser.isAssisting(eq(courseEdition))).thenReturn(true);
 		
 		when(delivery.getGroup()).thenReturn(group);
 		when(delivery.getAssignment()).thenReturn(assignment);
@@ -109,12 +110,12 @@ public class DeliveriesBackendTest extends BackendTest {
 		when(group.getCourseEdition()).thenReturn(courseEdition);
 		when(group.getMembers()).thenReturn(groupMembers);
 		
-		when(storageBackend.store(Matchers.anyString(), Matchers.eq(fileName), Matchers.eq(in))).thenReturn(FULL_PATH_NAME);
-		when(storageBackend.getFile(Matchers.eq(FULL_PATH_NAME))).thenReturn(file);
+		when(storageBackend.store(anyString(), eq(fileName), eq(in))).thenReturn(FULL_PATH_NAME);
+		when(storageBackend.getFile(eq(FULL_PATH_NAME))).thenReturn(file);
 		
 		when(attachment.getPath()).thenReturn(FULL_PATH_NAME);
 
-		when(deliveriesDAO.getLastDelivery(Matchers.eq(assignment), Matchers.eq(group))).thenReturn(Optional.empty());
+		when(deliveriesDAO.getLastDelivery(eq(assignment), eq(group))).thenReturn(Optional.empty());
 	}
 	
 	@Test
@@ -162,7 +163,7 @@ public class DeliveriesBackendTest extends BackendTest {
 
 	private void isAGroupMember() {
 		when(currentUser.isAdmin()).thenReturn(false);
-		when(currentUser.isAssisting(Matchers.eq(courseEdition))).thenReturn(false);
+		when(currentUser.isAssisting(eq(courseEdition))).thenReturn(false);
 	}
 	
 	@Test(expected=UnauthorizedException.class)
@@ -174,13 +175,13 @@ public class DeliveriesBackendTest extends BackendTest {
 
 	private void hasNoPermission() {
 		when(currentUser.isAdmin()).thenReturn(false);
-		when(currentUser.isAssisting(Matchers.eq(courseEdition))).thenReturn(false);
+		when(currentUser.isAssisting(eq(courseEdition))).thenReturn(false);
 		when(group.getMembers()).thenReturn(Sets.newHashSet());
 	}
 	
 	@Test(expected=IllegalStateException.class)
 	public void whenAlreadyApprovedOrDisapprovedRejectDelivery() throws UnauthorizedException, ApiError {
-		when(deliveriesDAO.lastDeliveryIsApprovedOrDisapproved(Matchers.eq(assignment), Matchers.eq(group)))
+		when(deliveriesDAO.lastDeliveryIsApprovedOrDisapproved(eq(assignment), eq(group)))
 			.thenReturn(true);
 		
 		this.deliveriesBackend.deliver(delivery);
@@ -189,7 +190,7 @@ public class DeliveriesBackendTest extends BackendTest {
 	@SuppressWarnings("unchecked")
 	@Test(expected=ApiError.class)
 	public void whenStoringDeliveryFailedErrorToUser() throws UnauthorizedException, ApiError {
-		when(deliveriesDAO.persist(Matchers.eq(delivery))).thenThrow(Exception.class);
+		when(deliveriesDAO.persist(eq(delivery))).thenThrow(Exception.class);
 		
 		this.deliveriesBackend.deliver(delivery);
 	}
@@ -248,7 +249,7 @@ public class DeliveriesBackendTest extends BackendTest {
 	@SuppressWarnings("unchecked")
 	@Test(expected=ApiError.class)
 	public void whenAttachingDeliveryFailedErrorToUser() throws UnauthorizedException, ApiError {
-		when(deliveriesDAO.merge(Matchers.eq(delivery))).thenThrow(Exception.class);
+		when(deliveriesDAO.merge(eq(delivery))).thenThrow(Exception.class);
 		
 		attachedFile();
 	}
@@ -257,7 +258,7 @@ public class DeliveriesBackendTest extends BackendTest {
 	public void reviewDelivery() throws UnauthorizedException, ApiError {
 		this.deliveriesBackend.review(delivery, review);
 		
-		verify(delivery).setReview(Matchers.eq(review));
+		verify(delivery).setReview(eq(review));
 	}
 	
 	@Test
@@ -291,7 +292,7 @@ public class DeliveriesBackendTest extends BackendTest {
 	@SuppressWarnings("unchecked")
 	@Test(expected=ApiError.class)
 	public void whenReviewingDeliveryFailedErrorToUser() throws UnauthorizedException, ApiError {
-		when(deliveriesDAO.merge(Matchers.eq(delivery))).thenThrow(Exception.class);
+		when(deliveriesDAO.merge(eq(delivery))).thenThrow(Exception.class);
 		
 		reviewDelivery();
 	}
@@ -346,7 +347,7 @@ public class DeliveriesBackendTest extends BackendTest {
 	@Test
 	public void assignmentStatsFromLatestDeliveries() {
 		when(assignment.getCourseEdition()).thenReturn(courseEdition);
-		when(deliveriesDAO.getLastDeliveries(Matchers.eq(assignment))).thenReturn(deliveries);
+		when(deliveriesDAO.getLastDeliveries(eq(assignment))).thenReturn(deliveries);
 		
 		assertNotNull(this.deliveriesBackend.getAssignmentStats(assignment));
 	}

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/IssueBackendTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/IssueBackendTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import nl.tudelft.ewi.devhub.server.database.controllers.CourseEditions;
 import nl.tudelft.ewi.devhub.server.database.controllers.Groups;

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/SshKeyBackendTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/SshKeyBackendTest.java
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/CheckstyleWarningGeneratorTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/CheckstyleWarningGeneratorTest.java
@@ -61,14 +61,12 @@ public class CheckstyleWarningGeneratorTest {
     @Before
     public void initializeMocks(){
         when(commit.getCommitId()).thenReturn(COMMIT_ID);
-		  when(commit.getRepository()).thenReturn(groupRepository);
-		  when(group.getRepository()).thenReturn(groupRepository);
-		  when(groupRepository.getRepositoryName()).thenReturn("");
+        when(commit.getRepository()).thenReturn(groupRepository);
+        when(groupRepository.getRepositoryName()).thenReturn("");
         when(commits.ensureExists(any(), any())).thenReturn(commit);
 
         when(repositories.getRepository(anyString())).thenReturn(repository);
         when(repository.getCommit(COMMIT_ID)).thenReturn(commitApi);
-        when(commitApi.get()).thenReturn(repoCommit);
         blameCurrentCommit();
     }
 

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/CheckstyleWarningGeneratorTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/CheckstyleWarningGeneratorTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.io.InputStreamReader;

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/FindBugsWarningGeneratorTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/FindBugsWarningGeneratorTest.java
@@ -65,13 +65,11 @@ public class FindBugsWarningGeneratorTest {
     public void initializeMocks() {
         when(commit.getCommitId()).thenReturn(COMMIT_ID);
         when(commit.getRepository()).thenReturn(groupRepository);
-        when(group.getRepository()).thenReturn(groupRepository);
         when(groupRepository.getRepositoryName()).thenReturn("");
         when(commits.ensureExists(any(), any())).thenReturn(commit);
 
         when(repositories.getRepository(anyString())).thenReturn(repository);
         when(repository.getCommit(COMMIT_ID)).thenReturn(commitApi);
-        when(commitApi.get()).thenReturn(repoCommit);
 
         blameCurrentCommit();
     }

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/FindBugsWarningGeneratorTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/FindBugsWarningGeneratorTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.io.InputStreamReader;

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/IgnoredFileWarningTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/IgnoredFileWarningTest.java
@@ -78,10 +78,8 @@ public class IgnoredFileWarningTest {
 
         when(repositories.getRepository(anyString())).thenReturn(repository);
         when(repository.getCommit(COMMIT_ID)).thenReturn(commitApi);
-        when(commitApi.get()).thenReturn(commitModel);
         when(commitApi.diff()).thenReturn(diffModel);
 
-        
         warning = new IgnoredFileWarning();
         warning.setRepository(groupRepository);
         warning.setCommit(commitEntity);

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/IgnoredFileWarningTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/IgnoredFileWarningTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.Lists;
 

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/IllegalFileWarningTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/IllegalFileWarningTest.java
@@ -66,7 +66,6 @@ public class IllegalFileWarningTest {
 
         when(repositories.getRepository(anyString())).thenReturn(repository);
         when(repository.getCommit(COMMIT_ID)).thenReturn(commitApi);
-        when(commitApi.get()).thenReturn(commitModel);
         when(commitApi.showTree("")).thenReturn(directory1);
 
         directory1.clear();

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/IllegalFileWarningTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/IllegalFileWarningTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/LargeCommitWarningGeneratorTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/LargeCommitWarningGeneratorTest.java
@@ -16,7 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/LargeFileWarningGeneratorTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/LargeFileWarningGeneratorTest.java
@@ -63,7 +63,6 @@ public class LargeFileWarningGeneratorTest {
 
         when(repositories.getRepository(anyString())).thenReturn(repository);
         when(repository.getCommit(COMMIT_ID)).thenReturn(commitApi);
-        when(commitApi.get()).thenReturn(commitModel);
         when(commitApi.diff()).thenReturn(diffModel);
         when(commitApi.showTree(anyString())).thenReturn(ImmutableMap.of(FILE_PATH, EntryType.TEXT));
         when(diffModel.getDiffs()).thenReturn(diffValues);

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/LargeFileWarningGeneratorTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/LargeFileWarningGeneratorTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/PMDWarningGeneratorTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/PMDWarningGeneratorTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.io.InputStreamReader;

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/PMDWarningGeneratorTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/PMDWarningGeneratorTest.java
@@ -62,13 +62,11 @@ public class PMDWarningGeneratorTest {
     public void initializeMocks() {
         when(commit.getCommitId()).thenReturn(COMMIT_ID);
         when(commit.getRepository()).thenReturn(groupRepository);
-		when(group.getRepository()).thenReturn(groupRepository);
         when(groupRepository.getRepositoryName()).thenReturn("");
         when(commits.ensureExists(any(), any())).thenReturn(commit);
 
         when(repositories.getRepository(anyString())).thenReturn(repository);
         when(repository.getCommit(COMMIT_ID)).thenReturn(commitApi);
-        when(commitApi.get()).thenReturn(repoCommit);
         blameCurrentCommit();
     }
 

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/PullRequestWarningGeneratorTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/PullRequestWarningGeneratorTest.java
@@ -56,15 +56,11 @@ public class PullRequestWarningGeneratorTest {
     public void beforeTest() throws Exception {
         when(commitEntity.getCommitId()).thenReturn(COMMIT_ID);
 		when(commitEntity.getRepository()).thenReturn(groupRepository);
-		when(group.getRepository()).thenReturn(groupRepository);
 		when(groupRepository.getRepositoryName()).thenReturn("");
 
         when(repositories.getRepository(anyString())).thenReturn(repository);
-        when(repository.getCommit(COMMIT_ID)).thenReturn(commitApi);
         when(commitApi.get()).thenReturn(repoCommit);
         when(repository.getBranch(MASTER)).thenReturn(branchApi);
-        when(branchApi.get()).thenReturn(branchModel);
-        when(branchModel.getCommit()).thenReturn(repoCommit);
         when(branchApi.getCommit()).thenReturn(commitApi);
 
         warning = new GitUsageWarning();
@@ -90,7 +86,6 @@ public class PullRequestWarningGeneratorTest {
     @Test
     public void testCommitNotOnHead() {
         when(repoCommit.getCommit()).thenReturn(OTHER_COMMIT_ID);
-        when(repoCommit.getParents()).thenReturn(new String[] { "fe30124" });
         Set<GitUsageWarning> warns = generator.generateWarnings(commitEntity, null);
         assertEquals(warns, Collections.<GitUsageWarning>emptySet());
     }
@@ -98,7 +93,6 @@ public class PullRequestWarningGeneratorTest {
     @Test
     public void testMergeCommitNotOnHead() {
         when(repoCommit.getCommit()).thenReturn(OTHER_COMMIT_ID);
-        when(repoCommit.getParents()).thenReturn(new String[] { "fe30124", "ab30124" });
         Set<GitUsageWarning> warns = generator.generateWarnings(commitEntity, null);
         assertEquals(warns, Collections.<GitUsageWarning>emptySet());
     }

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/PullRequestWarningGeneratorTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/PullRequestWarningGeneratorTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 import java.util.Set;

--- a/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/SuccessiveBuildFailureTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/backend/warnings/SuccessiveBuildFailureTest.java
@@ -62,6 +62,7 @@ public class SuccessiveBuildFailureTest {
         MockitoAnnotations.initMocks(this);
         when(commitEntity.getCommitId()).thenReturn(COMMIT_ID);
 		when(commitEntity.getRepository()).thenReturn(groupRepository);
+        when(groupRepository.getRepositoryName()).thenReturn("");
 		when(group.getRepository()).thenReturn(groupRepository);
 
         when(repositories.getRepository(anyString())).thenReturn(repository);

--- a/src/test/java/nl/tudelft/ewi/devhub/server/util/FlattenFolderTreeTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/util/FlattenFolderTreeTest.java
@@ -55,7 +55,6 @@ public class FlattenFolderTreeTest {
         final LinkedHashMap<String, EntryType> barFolderTree = Maps.newLinkedHashMap();
         barFolderTree.put("Bar.java", EntryType.TEXT);
 
-        when(commitApi.showTree()).thenReturn(rootTree);
         when(commitApi.showTree(CommitApi.EMPTY_PATH)).thenReturn(rootTree);
         when(commitApi.showTree("src/")).thenReturn(srcFolderTree);
         when(commitApi.showTree("src/main/")).thenReturn(mainFolderTree);

--- a/src/test/java/nl/tudelft/ewi/devhub/server/util/FlattenFolderTreeTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/util/FlattenFolderTreeTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/BuildServerRegistrationTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/BuildServerRegistrationTest.java
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotAuthorizedException;

--- a/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/BuildServerRegistrationTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/BuildServerRegistrationTest.java
@@ -78,7 +78,6 @@ public class BuildServerRegistrationTest {
 		when(userApi.keys()).thenReturn(keysApi);
 
 		when(groupsApi.getGroup(BuildServerRegistrationResource.BUILD_SERVERS_GROUP)).thenReturn(groupApi);
-		when(groupApi.getGroup()).thenReturn(groupModel);
 		when(groupApi.listMembers()).thenReturn(groupModel.getMembers());
 
 		when(keysApi.listSshKeys()).thenReturn(Collections.singleton(sshKeyModel));

--- a/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResourceTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResourceTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectAssignmentsResourceTest {

--- a/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResourceTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResourceTest.java
@@ -51,14 +51,12 @@ public class ProjectAssignmentsResourceTest {
 
     @Test
     public void testNotReleasedAdmin() {
-        Mockito.when(assignment.isGradesReleased()).thenReturn(false);
         Mockito.when(user.isAdmin()).thenReturn(true);
         assertTrue(resource.canSeeGrade(assignment));
     }
 
     @Test
     public void testNotReleasedTA() {
-        Mockito.when(assignment.isGradesReleased()).thenReturn(false);
         Mockito.when(user.isAssisting(edition)).thenReturn(true);
         assertTrue(resource.canSeeGrade(assignment));
     }

--- a/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectPullResourceTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectPullResourceTest.java
@@ -16,7 +16,6 @@ import nl.tudelft.ewi.git.web.api.RepositoriesApi;
 import org.jukito.JukitoRunner;
 import org.jukito.UseModules;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -29,7 +28,6 @@ import java.net.URI;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -63,7 +61,7 @@ public class AbstractProjectPullResourceTest {
         groupRepository.setRepositoryName(REPOSITORY_NAME);
         group.setRepository(groupRepository);
 
-        when(pullRequests.findById(anyObject(), eq(PULL_ID))).thenReturn(pullRequest);
+        when(pullRequests.findById(any(), eq(PULL_ID))).thenReturn(pullRequest);
 
         projectPullResource = spy(new ProjectPullResource(templateEngine, currentUser, group, null,
                 null, pullRequests, null, repositoriesApi, commentMailer, null,
@@ -73,7 +71,7 @@ public class AbstractProjectPullResourceTest {
         when(currentUser.getName()).thenReturn(REPOSITORY_NAME);
         when(pullRequest.getURI()).thenReturn(new URI(PULL_URI));
         doReturn(pullRequestComment).when(projectPullResource).pullRequestCommentFactory(anyString(),
-                anyObject());
+                any());
 
         when(request.getLocales()).thenReturn(new Vector<Locale>().elements());
 

--- a/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectPullResourceTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectPullResourceTest.java
@@ -20,7 +20,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRule;
+import org.mockito.MockitoAnnotations;
 import org.pegdown.PegDownProcessor;
 
 import javax.servlet.http.HttpServletRequest;
@@ -52,13 +52,12 @@ public class AbstractProjectPullResourceTest {
 
     @Inject private RepositoriesApi repositoriesApi;
 
-    @Rule public MockitoJUnitRule mockitoJUnitRule = new MockitoJUnitRule(this);
-
     private ProjectPullResource projectPullResource;
     private Date commentDate = new Date(150);
 
     @Before
     public void setUp() throws Throwable {
+        MockitoAnnotations.initMocks(this);
         Group group = new Group();
         GroupRepository groupRepository = new GroupRepository();
         groupRepository.setRepositoryName(REPOSITORY_NAME);

--- a/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectResourceTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectResourceTest.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -88,7 +88,7 @@ public class AbstractProjectResourceTest {
         groupRepository.setRepositoryName(REPOSITORY_NAME);
         group.setRepository(groupRepository);
 
-        when(commits.ensureExists(anyObject(), anyObject())).thenReturn(commit);
+        when(commits.ensureExists(any(), any())).thenReturn(commit);
 
         projectResource = spy(new ProjectResource(templateEngine, currentUser, group, null, null,
                 null, repositoriesApi, null, commitComments, commentMailer, commits, null, null,
@@ -96,7 +96,7 @@ public class AbstractProjectResourceTest {
 
         when(commitComment.getTimestamp()).thenReturn(commentDate);
         when(currentUser.getName()).thenReturn(REPOSITORY_NAME);
-        doReturn(commitComment).when(projectResource).commitCommentFactory(anyString(), anyObject(),
+        doReturn(commitComment).when(projectResource).commitCommentFactory(anyString(), any(),
                 eq(COMMIT_ID));
 
         when(request.getLocales()).thenReturn(new Vector<Locale>().elements());
@@ -113,7 +113,7 @@ public class AbstractProjectResourceTest {
         cloneStepDefinitions.isAheadOf(BRANCH_NAME, "master");
 
         Response response = projectResource.deleteBehindBranch(request, BRANCH_NAME, "");
-        verify(templateEngine).process(anyString(), anyObject(), argumentCaptor.capture());
+        verify(templateEngine).process(anyString(), any(), argumentCaptor.capture());
         System.out.println("\n\n\n\n\n=======1:\n" + argumentCaptor.getValue());
 
     }*/

--- a/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectResourceTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/server/web/resources/repository/AbstractProjectResourceTest.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRule;
+import org.mockito.MockitoAnnotations;
 import org.pegdown.PegDownProcessor;
 
 import javax.servlet.http.HttpServletRequest;
@@ -63,8 +63,6 @@ public class AbstractProjectResourceTest {
     @Inject private RepositoriesApi repositoriesApi;
     @Inject private Injector injector;
 
-    @Rule public MockitoJUnitRule mockitoJUnitRule = new MockitoJUnitRule(this);
-
     private CloneStepDefinitions cloneStepDefinitions;
     private MergeStepDefinitions mergeStepDefinitions;
     private DetailedRepositoryModel detailedRepositoryModel;
@@ -73,6 +71,7 @@ public class AbstractProjectResourceTest {
 
     @Before
     public void setUp() throws Throwable {
+        MockitoAnnotations.initMocks(this);
         cloneStepDefinitions = new CloneStepDefinitions();
         injector.injectMembers(cloneStepDefinitions);
 

--- a/src/test/java/nl/tudelft/ewi/devhub/webtests/ProjectResourceTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/webtests/ProjectResourceTest.java
@@ -24,7 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.inject.Inject;
 import java.io.File;

--- a/src/test/java/nl/tudelft/ewi/devhub/webtests/ProjectResourceTest.java
+++ b/src/test/java/nl/tudelft/ewi/devhub/webtests/ProjectResourceTest.java
@@ -33,7 +33,7 @@ import java.net.URI;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ProjectResourceTest extends WebTest {
 
     // Commit constants


### PR DESCRIPTION
This PR upgrades Mockito to 2.8.3. It migrates deprecated method calls, removes usage of the MockitoJUnitRule and removes unused stubbings as caught by strict stubbing.