### PR TITLE
Escape delivery ids in the group assignment view

### DIFF
--- a/src/main/resources/templates/courses/assignments/group-assignment-view.ftl
+++ b/src/main/resources/templates/courses/assignments/group-assignment-view.ftl
@@ -45,10 +45,10 @@
                     [#if user.isAdmin() || user.isAssisting(course)]
                         [#if delivery_index == 0]
                         <div class="pull-right">
-                          <a href="deliveries/${delivery.getDeliveryId()}/review" class="btn btn-default">${i18n.translate("button.label.review")}</a>
+                          <a href="deliveries/${delivery.getDeliveryId()?c}/review" class="btn btn-default">${i18n.translate("button.label.review")}</a>
                         </div>
                         [#else]
-	                      <a href="deliveries/${delivery.getDeliveryId()}/review" class="btn btn-link">${i18n.translate("button.label.previous-review")}</a>
+	                      <a href="deliveries/${delivery.getDeliveryId()?c}/review" class="btn btn-link">${i18n.translate("button.label.previous-review")}</a>
                         [/#if]
                     [/#if]
                     </td>


### PR DESCRIPTION
Id's above 1000 would get a , inserted by freemarker.
causing a 404 because we can't find the resource. the ?c
tells freemarker the number is for machine purposes and not for humans.
This escapes it from the freemarker number parsing.