### PR TITLE
Remove .gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto


### PR DESCRIPTION
We should enforce this some other way, as this only worsened things on my linux box.

@TimvdLippe  
You added this line, what was the idea behind this, maybe I am doing something wrong, but at least on my linux machine this seemed to only worsen the situation.