### PR TITLE
Add chromium dependency to resolve the libbase.so dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ addons:
   apt:
     packages:
       - oracle-java8-installer
-      - google-chrome-stable
       - chromium-browser
-    sources:
-      - google-chrome
 jdk:
   - oraclejdk8
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     packages:
       - oracle-java8-installer
       - google-chrome-stable
+      - chromium-browser
     sources:
       - google-chrome
 jdk:


### PR DESCRIPTION
We added a shared object file to the path for the chrome-driver (libbase.so).
This object file is located in the chromium package.
I believe that chromium is no longer installed by default in the Travis image.
This is what broke the web tests even though we changed nothing.

The current workaround is installing chromium explicitly installing chromium.
Perhaps we should look at either running the tests in Chromium itself or find this dependency in chrome?