### PR TITLE
Compute state and grade on review if rubrics and grading strategy is used

### DIFF
--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Assignment.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Assignment.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import nl.tudelft.ewi.devhub.server.database.Base;
 import nl.tudelft.ewi.devhub.server.database.entities.identity.FKSegmentedIdentifierGenerator;
+import nl.tudelft.ewi.devhub.server.database.entities.rubrics.Characteristic;
 import nl.tudelft.ewi.devhub.server.database.entities.rubrics.DutchGradingStrategy;
 import nl.tudelft.ewi.devhub.server.database.entities.rubrics.GradingStrategy;
 import nl.tudelft.ewi.devhub.server.database.entities.rubrics.Task;
@@ -108,6 +109,20 @@ public class Assignment implements Comparable<Assignment>, Base {
 	@JsonManagedReference
 	@OneToMany(mappedBy = "assignment", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
 	private List<Task> tasks;
+
+	@JsonIgnore
+	public List<Characteristic> getCharacteristics() {
+		return tasks.stream()
+			.map(Task::getCharacteristics)
+			.flatMap(java.util.Collection::stream)
+			.distinct()
+			.collect(Collectors.toList());
+	}
+
+	@JsonIgnore
+	public boolean isAssignmentHasRubrics() {
+		return !tasks.isEmpty() && getGradingStrategy() != null;
+	}
 
     @Override
     public int compareTo(Assignment o) {

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Delivery.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/Delivery.java
@@ -222,6 +222,12 @@ public class Delivery implements Event, Base {
         return review == null ? State.SUBMITTED : review.getState() == null ? State.SUBMITTED : review.getState();
     }
 
+    @JsonIgnore
+    public boolean isAllRubricsHaveBeenFilledIn() {
+	    return !getAssignment().isAssignmentHasRubrics() ||
+            getRubrics().keySet().size() == getAssignment().getCharacteristics().size();
+    }
+
 	@JsonIgnore
     public boolean isSubmitted() {
         return getState().equals(State.SUBMITTED);

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/DutchGradingStrategy.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/DutchGradingStrategy.java
@@ -11,7 +11,11 @@ public class DutchGradingStrategy implements GradingStrategy {
     public static final double THRESHOLD = 5.75;
 
     @Override
-    public double createGrade(Delivery delivery) {
+    public double createGrade(Delivery delivery) throws MissingRubricsException {
+        if (! delivery.isAllRubricsHaveBeenFilledIn()) {
+            throw new MissingRubricsException();
+        }
+
         return Math.max(
             1,
             delivery.getAchievedNumberOfPoints() / delivery.getAssignment().getNumberOfAchievablePoints() * 10
@@ -19,7 +23,7 @@ public class DutchGradingStrategy implements GradingStrategy {
     }
 
     @Override
-    public State createState(Delivery delivery) {
+    public State createState(Delivery delivery) throws MissingRubricsException {
         return createGrade(delivery) >= THRESHOLD ? State.APPROVED : State.DISAPPROVED;
     }
 

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/GradingException.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/GradingException.java
@@ -1,0 +1,7 @@
+package nl.tudelft.ewi.devhub.server.database.entities.rubrics;
+
+/**
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class GradingException extends RuntimeException {
+}

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/GradingStrategy.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/GradingStrategy.java
@@ -11,8 +11,8 @@ import nl.tudelft.ewi.devhub.server.database.entities.Delivery.Review;
  */
 public interface GradingStrategy {
 
-    double createGrade(Delivery delivery);
+    double createGrade(Delivery delivery) throws GradingException;
 
-    Delivery.State createState(Delivery delivery);
+    Delivery.State createState(Delivery delivery) throws GradingException;
 
 }

--- a/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/MissingRubricsException.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/database/entities/rubrics/MissingRubricsException.java
@@ -1,0 +1,7 @@
+package nl.tudelft.ewi.devhub.server.database.entities.rubrics;
+
+/**
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class MissingRubricsException extends GradingException {
+}

--- a/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResource.java
+++ b/src/main/java/nl/tudelft/ewi/devhub/server/web/resources/ProjectAssignmentsResource.java
@@ -23,6 +23,8 @@ import nl.tudelft.ewi.devhub.server.database.entities.Group;
 import nl.tudelft.ewi.devhub.server.database.entities.RepositoryEntity;
 import nl.tudelft.ewi.devhub.server.database.entities.User;
 import nl.tudelft.ewi.devhub.server.database.entities.rubrics.Characteristic;
+import nl.tudelft.ewi.devhub.server.database.entities.rubrics.GradingException;
+import nl.tudelft.ewi.devhub.server.database.entities.rubrics.GradingStrategy;
 import nl.tudelft.ewi.devhub.server.database.entities.rubrics.Mastery;
 import nl.tudelft.ewi.devhub.server.database.entities.rubrics.Task;
 import nl.tudelft.ewi.devhub.server.web.errors.ApiError;
@@ -340,14 +342,28 @@ public class ProjectAssignmentsResource extends Resource {
                                   @PathParam("deliveryId") Long deliveryId,
                                   @FormParam("grade") String grade,
                                   @FormParam("commentary") String commentary,
-                                  @FormParam("state") Delivery.State state) throws UnauthorizedException, ApiError {
+                                  @FormParam("state") Delivery.State state) throws UnauthorizedException, ApiError, GradingException {
 
         if(!(currentUser.isAdmin() || currentUser.isAssisting(group.getCourse()))) {
             throw new UnauthorizedException();
         }
 
-        Double gradeValue = grade.isEmpty() ? null : Double.valueOf(grade);
         Delivery delivery = deliveries.find(group, deliveryId);
+        Assignment assignment = delivery.getAssignment();
+        GradingStrategy gradingStrategy = assignment.getGradingStrategy();
+
+        Double gradeValue;
+
+        if (assignment.isAssignmentHasRubrics()) {
+            // MissingRubricExceptions should not happen here as the review button
+            // is disabled until all characteristics have been filled in
+            gradeValue = gradingStrategy.createGrade(delivery);
+            state = gradingStrategy.createState(delivery);
+        }
+        else {
+            gradeValue = grade.isEmpty() ? null : Double.valueOf(grade);
+        }
+
         Delivery.Review review = new Delivery.Review();
         review.setState(state);
         review.setGrade(gradeValue);

--- a/src/main/resources/templates/courses/assignments/group-delivery-review.ftl
+++ b/src/main/resources/templates/courses/assignments/group-delivery-review.ftl
@@ -40,7 +40,7 @@
                             <div class="row">
                                 <div class="form-group col-md-6">
                                     <label for="state">${i18n.translate("delivery.status")}</label>
-                                    <select class="form-control" name="state" id="state">
+                                    <select class="form-control" name="state" id="state" [#if delivery.assignment.tasks?has_content && delivery.assignment.gradingStrategy?has_content]disabled="disabled"[/#if]>
                                         [#if deliveryStates?? && deliveryStates?has_content]
                                             [#list deliveryStates as deliveryState]
                                                 <option value="${deliveryState?string}" [#if review?? && review?has_content && review.getState() == deliveryState]selected[/#if]>
@@ -53,7 +53,9 @@
 
                                 <div class="form-group col-md-6">
                                     <label for="grade">${i18n.translate("delivery.grade")}</label>
-                                    <input type="number" class="form-control" name="grade" id="grade" min="1" max="10" step="0.1" [#if review?? && review?has_content ]value="${review.getGrade()!}"[/#if]>
+                                    <input type="number" class="form-control" name="grade" id="grade" min="1" max="10" step="0.1"
+																					 [#if review?? && review?has_content ]value="${review.getGrade()!}"[/#if]
+																					 [#if delivery.assignment.tasks?has_content && delivery.assignment.gradingStrategy?has_content]disabled="disabled"[/#if]>
                                 </div>
                             </div>
 


### PR DESCRIPTION
This PR disables the grade and submission state inputs for TA's whenever a grading strategy is in place combined with any rubrics. Instead these fields are now generated right after finishing the review.

We currently do not update the grade when there is any change to the rubrics (for example the weights, or adding a new rubric). When the grades are released (or re-released), the grades will be re-computed. We may want to change the workflow here as this may be surprising. Recomputing the existing grades and statusses whenever the rubrics are changed probably makes more sense, and would make our "release and compute all" logic unnecessary.